### PR TITLE
Session-Aware Capture

### DIFF
--- a/docs/UBIQUITOUS_LANGUAGE.md
+++ b/docs/UBIQUITOUS_LANGUAGE.md
@@ -48,6 +48,7 @@
 ## Relationships
 
 - A **Session** is associated with exactly one **Source**
+- A **Source** can have many **Sessions**
 - A **Session** has many **Captures**
 - A **Capture** belongs to exactly one **Session** or is a **One-off**
 - A **Capture** may include a **Locator** (chapter, page, timestamp)

--- a/packages/server/prisma/migrations/20260429162509_init/migration.sql
+++ b/packages/server/prisma/migrations/20260429162509_init/migration.sql
@@ -1,9 +1,0 @@
--- CreateTable
-CREATE TABLE "AppMeta" (
-    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    "key" TEXT NOT NULL,
-    "value" TEXT NOT NULL
-);
-
--- CreateIndex
-CREATE UNIQUE INDEX "AppMeta_key_key" ON "AppMeta"("key");

--- a/packages/server/prisma/migrations/20260513082850_init/migration.sql
+++ b/packages/server/prisma/migrations/20260513082850_init/migration.sql
@@ -1,4 +1,11 @@
 -- CreateTable
+CREATE TABLE "AppMeta" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL
+);
+
+-- CreateTable
 CREATE TABLE "Capture" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "rawText" TEXT NOT NULL,
@@ -16,3 +23,6 @@ CREATE TABLE "Session" (
     "sourceName" TEXT NOT NULL,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AppMeta_key_key" ON "AppMeta"("key");

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -26,9 +26,11 @@ model Capture {
 }
 
 model Session {
-  id        Int      @id @default(autoincrement())
+  id         Int       @id @default(autoincrement())
   sourceName String
-  createdAt DateTime @default(now())
+  type       String
+  createdAt  DateTime  @default(now())
+  closedAt   DateTime?
 
-  captures  Capture[]
+  captures   Capture[]
 }

--- a/packages/server/src/__tests__/session.test.ts
+++ b/packages/server/src/__tests__/session.test.ts
@@ -1,0 +1,54 @@
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "../generated/prisma/client.js";
+import { appRouter } from "../router.js";
+import type { LLMClient } from "../services/llm-client.js";
+
+describe("session.open mutation", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/dev.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const mockLLM: LLMClient = {
+    complete: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+      }),
+    ),
+  } as unknown as LLMClient;
+
+  it("creates a session with source name and type, leaves it open (closedAt null)", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const result = await caller.session.open({
+      sourceName: "Moby Dick",
+      type: "book",
+    });
+
+    expect(result).toMatchObject({
+      sourceName: "Moby Dick",
+      type: "book",
+      closedAt: null,
+    });
+
+    // Verify persisted
+    const found = await prisma.session.findUnique({
+      where: { id: result.id },
+    });
+    expect(found).toMatchObject({
+      sourceName: "Moby Dick",
+      type: "book",
+      closedAt: null,
+    });
+
+    // Cleanup
+    await prisma.session.delete({ where: { id: result.id } });
+  });
+});

--- a/packages/server/src/__tests__/session.test.ts
+++ b/packages/server/src/__tests__/session.test.ts
@@ -51,4 +51,66 @@ describe("session.open mutation", () => {
     // Cleanup
     await prisma.session.delete({ where: { id: result.id } });
   });
+
+  it("throws when another session is already active", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    // Open first session
+    const first = await caller.session.open({
+      sourceName: "Moby Dick",
+      type: "book",
+    });
+
+    // Second open should throw
+    await expect(
+      caller.session.open({ sourceName: "Another Book", type: "book" }),
+    ).rejects.toThrow();
+
+    // Cleanup
+    await prisma.session.delete({ where: { id: first.id } });
+  });
+});
+
+describe("session.close mutation", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/dev.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const mockLLM: LLMClient = {
+    complete: vi
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({ item: "test", locator: null, sourceHint: null }),
+      ),
+  } as unknown as LLMClient;
+
+  it("sets closedAt on the active session, allowing a new one to be opened", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    // Open a session
+    const session = await caller.session.open({
+      sourceName: "Closing Time",
+      type: "article",
+    });
+
+    // Close it
+    const closed = await caller.session.close();
+    expect(closed.closedAt).not.toBeNull();
+    expect(closed.id).toBe(session.id);
+
+    // Now we should be able to open a new session
+    const second = await caller.session.open({
+      sourceName: "Second Session",
+      type: "video",
+    });
+    expect(second.closedAt).toBeNull();
+
+    // Cleanup
+    await prisma.session.deleteMany();
+  });
 });

--- a/packages/server/src/__tests__/session.test.ts
+++ b/packages/server/src/__tests__/session.test.ts
@@ -114,3 +114,125 @@ describe("session.close mutation", () => {
     await prisma.session.deleteMany();
   });
 });
+
+describe("session.getActive query", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/dev.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const mockLLM: LLMClient = {
+    complete: vi
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({ item: "test", locator: null, sourceHint: null }),
+      ),
+  } as unknown as LLMClient;
+
+  it("returns null when no session is active", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+    const result = await caller.session.getActive();
+    expect(result).toBeNull();
+  });
+
+  it("returns the active session when one is open", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const session = await caller.session.open({
+      sourceName: "Active Test",
+      type: "book",
+    });
+
+    const result = await caller.session.getActive();
+    expect(result).toMatchObject({
+      id: session.id,
+      sourceName: "Active Test",
+      type: "book",
+      closedAt: null,
+    });
+
+    // Cleanup
+    await prisma.session.delete({ where: { id: session.id } });
+  });
+});
+
+describe("captures scoped to a session", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/dev.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const mockLLM: LLMClient = {
+    complete: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        item: "session-word",
+        locator: "p.10",
+        sourceHint: null,
+      }),
+    ),
+  } as unknown as LLMClient;
+
+  it("associates a capture with the session when sessionId is provided", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const session = await caller.session.open({
+      sourceName: "Capture Book",
+      type: "book",
+    });
+
+    const capture = await caller.capture.create({
+      rawText: "session-word p.10",
+      sessionId: session.id,
+    });
+
+    expect(capture.sessionId).toBe(session.id);
+
+    // Verify persisted
+    const found = await prisma.capture.findUnique({
+      where: { id: capture.id },
+    });
+    expect(found?.sessionId).toBe(session.id);
+
+    // Cleanup
+    await prisma.capture.delete({ where: { id: capture.id } });
+    await prisma.session.delete({ where: { id: session.id } });
+  });
+
+  it("lists captures belonging to a session", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const session = await caller.session.open({
+      sourceName: "List Book",
+      type: "book",
+    });
+
+    await caller.capture.create({
+      rawText: "word-one p.5",
+      sessionId: session.id,
+    });
+    await caller.capture.create({
+      rawText: "word-two p.10",
+      sessionId: session.id,
+    });
+
+    const captures = await caller.capture.listSession({
+      sessionId: session.id,
+    });
+    expect(captures).toHaveLength(2);
+    expect(captures.map((c) => c.item)).toEqual(
+      expect.arrayContaining(["session-word", "session-word"]),
+    );
+
+    // Cleanup
+    await prisma.capture.deleteMany({ where: { sessionId: session.id } });
+    await prisma.session.delete({ where: { id: session.id } });
+  });
+});

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -26,6 +26,9 @@ export const appRouter = t.router({
       .mutation(async ({ input, ctx }) =>
         SessionService.open(input.sourceName, input.type, ctx.prisma),
       ),
+    close: t.procedure.mutation(async ({ ctx }) =>
+      SessionService.close(ctx.prisma),
+    ),
   }),
   capture: t.router({
     create: t.procedure

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -29,14 +29,32 @@ export const appRouter = t.router({
     close: t.procedure.mutation(async ({ ctx }) =>
       SessionService.close(ctx.prisma),
     ),
+    getActive: t.procedure.query(async ({ ctx }) =>
+      SessionService.getActive(ctx.prisma),
+    ),
   }),
   capture: t.router({
     create: t.procedure
-      .input(z.object({ rawText: z.string().min(1) }))
+      .input(
+        z.object({
+          rawText: z.string().min(1),
+          sessionId: z.number().optional(),
+        }),
+      )
       .mutation(async ({ input, ctx }) =>
-        CaptureService.create(input.rawText, ctx.prisma, ctx.llm),
+        CaptureService.create(
+          input.rawText,
+          ctx.prisma,
+          ctx.llm,
+          input.sessionId,
+        ),
       ),
     list: t.procedure.query(({ ctx }) => CaptureService.list(ctx.prisma)),
+    listSession: t.procedure
+      .input(z.object({ sessionId: z.number() }))
+      .query(async ({ input, ctx }) =>
+        CaptureService.listSession(input.sessionId, ctx.prisma),
+      ),
   }),
 });
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -2,6 +2,7 @@ import { initTRPC } from "@trpc/server";
 import { z } from "zod";
 import { AppService } from "./services/app.js";
 import { CaptureService } from "./services/capture.js";
+import { SessionService } from "./services/session.js";
 
 export interface AppContext {
   prisma: import("./generated/prisma/client.js").PrismaClient;
@@ -13,6 +14,18 @@ const t = initTRPC.context<AppContext>().create();
 export const appRouter = t.router({
   app: t.router({
     status: t.procedure.query(() => AppService.status()),
+  }),
+  session: t.router({
+    open: t.procedure
+      .input(
+        z.object({
+          sourceName: z.string().min(1),
+          type: z.enum(["book", "video", "article"]),
+        }),
+      )
+      .mutation(async ({ input, ctx }) =>
+        SessionService.open(input.sourceName, input.type, ctx.prisma),
+      ),
   }),
   capture: t.router({
     create: t.procedure

--- a/packages/server/src/services/capture.ts
+++ b/packages/server/src/services/capture.ts
@@ -3,7 +3,12 @@ import { CaptureParser } from "./capture-parser.js";
 import type { LLMClient } from "./llm-client.js";
 
 export const CaptureService = {
-  async create(rawText: string, prisma: PrismaClient, llm: LLMClient) {
+  async create(
+    rawText: string,
+    prisma: PrismaClient,
+    llm: LLMClient,
+    sessionId?: number,
+  ) {
     const parser = new CaptureParser(llm);
     const parsed = await parser.parse(rawText);
 
@@ -13,6 +18,7 @@ export const CaptureService = {
         item: parsed.item,
         locator: parsed.locator,
         sourceHint: parsed.sourceHint,
+        sessionId: sessionId ?? null,
       },
     });
   },
@@ -20,6 +26,13 @@ export const CaptureService = {
   async list(prisma: PrismaClient) {
     return prisma.capture.findMany({
       where: { sessionId: null },
+      orderBy: { createdAt: "desc" },
+    });
+  },
+
+  async listSession(sessionId: number, prisma: PrismaClient) {
+    return prisma.capture.findMany({
+      where: { sessionId },
       orderBy: { createdAt: "desc" },
     });
   },

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -1,9 +1,38 @@
+import { TRPCError } from "@trpc/server";
 import type { PrismaClient } from "../generated/prisma/client.js";
 
 export const SessionService = {
   async open(sourceName: string, type: string, prisma: PrismaClient) {
+    const active = await prisma.session.findFirst({
+      where: { closedAt: null },
+    });
+    if (active) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message:
+          "A session is already active. Close it before opening a new one.",
+      });
+    }
+
     return prisma.session.create({
       data: { sourceName, type },
+    });
+  },
+
+  async close(prisma: PrismaClient) {
+    const active = await prisma.session.findFirst({
+      where: { closedAt: null },
+    });
+    if (!active) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "No active session to close.",
+      });
+    }
+
+    return prisma.session.update({
+      where: { id: active.id },
+      data: { closedAt: new Date() },
     });
   },
 };

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -35,4 +35,10 @@ export const SessionService = {
       data: { closedAt: new Date() },
     });
   },
+
+  async getActive(prisma: PrismaClient) {
+    return prisma.session.findFirst({
+      where: { closedAt: null },
+    });
+  },
 };

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -1,0 +1,9 @@
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+export const SessionService = {
+  async open(sourceName: string, type: string, prisma: PrismaClient) {
+    return prisma.session.create({
+      data: { sourceName, type },
+    });
+  },
+};

--- a/packages/web/src/components/BottomTabBar.tsx
+++ b/packages/web/src/components/BottomTabBar.tsx
@@ -1,13 +1,13 @@
 import {
-  BookmarkIcon as BookmarkSolid,
-  BookOpenIcon as BookOpenSolid,
-  ClipboardDocumentListIcon as ClipboardSolid,
-} from "@heroicons/react/24/solid";
-import {
   BookmarkIcon as BookmarkOutline,
   BookOpenIcon as BookOpenOutline,
   ClipboardDocumentListIcon as ClipboardOutline,
 } from "@heroicons/react/24/outline";
+import {
+  BookmarkIcon as BookmarkSolid,
+  BookOpenIcon as BookOpenSolid,
+  ClipboardDocumentListIcon as ClipboardSolid,
+} from "@heroicons/react/24/solid";
 import { NavLink } from "react-router-dom";
 
 interface Tab {
@@ -44,7 +44,7 @@ export function BottomTabBar() {
       className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-divider bg-surface"
       aria-label="Main navigation"
     >
-      {tabs.map(tab => (
+      {tabs.map((tab) => (
         <NavLink key={tab.to} to={tab.to} className="flex flex-1">
           {({ isActive }) => {
             const Icon = isActive ? tab.solidIcon : tab.outlineIcon;

--- a/packages/web/src/screens/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen.tsx
@@ -33,15 +33,42 @@ function CaptureEntry({
   );
 }
 
+const SOURCE_TYPES = [
+  { value: "book", label: "Book" },
+  { value: "video", label: "Video" },
+  { value: "article", label: "Article" },
+] as const;
+
 export function CaptureScreen() {
   const [rawText, setRawText] = useState("");
   const [lastParsed, setLastParsed] = useState<string | null>(null);
 
+  // Session start form state
+  const [showSessionForm, setShowSessionForm] = useState(false);
+  const [sourceName, setSourceName] = useState("");
+  const [sourceType, setSourceType] =
+    useState<(typeof SOURCE_TYPES)[number]["value"]>("book");
+
   const utils = trpc.useUtils();
+
+  // Queries
+  const activeSession = trpc.session.getActive.useQuery();
   const captures = trpc.capture.list.useQuery();
+  const sessionCaptures = trpc.capture.listSession.useQuery(
+    { sessionId: activeSession.data?.id ?? 0 },
+    { enabled: activeSession.data != null },
+  );
+
+  // Mutations
   const createCapture = trpc.capture.create.useMutation({
-    onSuccess: data => {
-      utils.capture.list.invalidate();
+    onSuccess: (data) => {
+      if (activeSession.data) {
+        utils.capture.listSession.invalidate({
+          sessionId: activeSession.data.id,
+        });
+      } else {
+        utils.capture.list.invalidate();
+      }
       const parts = [data.item];
       if (data.locator) parts.push(data.locator);
       setLastParsed(parts.join(" \u00b7 "));
@@ -49,38 +76,169 @@ export function CaptureScreen() {
     },
   });
 
+  const openSession = trpc.session.open.useMutation({
+    onSuccess: () => {
+      utils.session.getActive.invalidate();
+      setShowSessionForm(false);
+      setSourceName("");
+    },
+  });
+
+  const closeSession = trpc.session.close.useMutation({
+    onSuccess: () => {
+      utils.session.getActive.invalidate();
+    },
+  });
+
+  // Handlers
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!rawText.trim() || createCapture.isPending) return;
 
-    await createCapture.mutateAsync({ rawText: rawText.trim() });
+    const input: { rawText: string; sessionId?: number } = {
+      rawText: rawText.trim(),
+    };
+    if (activeSession.data) {
+      input.sessionId = activeSession.data.id;
+    }
+
+    await createCapture.mutateAsync(input);
     setRawText("");
   }
 
-  const isEmpty = !captures.data || captures.data.length === 0;
-  const count = captures.data?.length ?? 0;
+  async function handleStartSession(e: React.FormEvent) {
+    e.preventDefault();
+    if (!sourceName.trim() || openSession.isPending) return;
+
+    await openSession.mutateAsync({
+      sourceName: sourceName.trim(),
+      type: sourceType,
+    });
+  }
+
+  function handleCloseSession() {
+    if (!closeSession.isPending) {
+      closeSession.mutate();
+    }
+  }
+
+  // Determine which captures to show
+  const activeCaptures = activeSession.data
+    ? (sessionCaptures.data ?? [])
+    : (captures.data ?? []);
+  const isEmpty = activeCaptures.length === 0;
+  const hasSession = activeSession.data != null;
 
   return (
-    <main className="flex flex-1 flex-col pb-32 relative">
+    <main className="flex flex-1 flex-col relative">
       {/* Top bar */}
       <header className="flex items-center justify-between px-5 pt-4 pb-2">
         <h1 className="font-display text-lg font-bold text-ink">Capture</h1>
-        {count > 0 && (
+        {activeCaptures.length > 0 && (
           <span className="rounded-full bg-accent-subtle px-2 text-xs text-dim">
-            {count}
+            {activeCaptures.length}
           </span>
         )}
       </header>
 
+      {/* Session header (active session state) */}
+      {hasSession && (
+        <div className="mx-5 mb-2 flex items-center justify-between rounded-button border border-divider bg-surface px-3 py-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-display text-sm font-semibold text-ink">
+              {activeSession.data?.sourceName}
+            </div>
+            <div className="mt-0.5 text-xs text-dim">
+              {activeSession.data?.type}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleCloseSession}
+            disabled={closeSession.isPending}
+            className="ml-2 shrink-0 rounded-button border border-divider px-3 py-1 text-xs font-medium text-dim transition-colors hover:border-red-200 hover:text-red-600 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+          >
+            {closeSession.isPending ? "\u2026" : "Close"}
+          </button>
+        </div>
+      )}
+
+      {/* Start session prompt (no session state) */}
+      {!hasSession && (
+        <div className="mx-5 mb-2">
+          {!showSessionForm ? (
+            <button
+              type="button"
+              onClick={() => setShowSessionForm(true)}
+              className="w-full rounded-button border border-dashed border-divider px-3 py-2.5 text-center text-sm text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer"
+            >
+              Start a Session
+            </button>
+          ) : (
+            <form
+              onSubmit={handleStartSession}
+              className="space-y-2 rounded-button border border-accent bg-surface p-3"
+            >
+              <input
+                type="text"
+                value={sourceName}
+                onChange={(e) => setSourceName(e.target.value)}
+                placeholder="Source title (e.g. Moby Dick)"
+                disabled={openSession.isPending}
+                className="w-full rounded-button border border-divider bg-surface px-3 py-2 font-ui text-sm text-ink placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+                // biome-ignore lint/a11y/noAutofocus: session start is the primary action when shown, autofocus is intentional
+                autoFocus
+              />
+              <div className="flex gap-2">
+                <select
+                  value={sourceType}
+                  onChange={(e) =>
+                    setSourceType(
+                      e.target.value as (typeof SOURCE_TYPES)[number]["value"],
+                    )
+                  }
+                  disabled={openSession.isPending}
+                  className="rounded-button border border-divider bg-surface px-3 py-2 font-ui text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 cursor-pointer"
+                >
+                  {SOURCE_TYPES.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="submit"
+                  disabled={openSession.isPending || !sourceName.trim()}
+                  className="flex-1 rounded-button bg-accent px-4 py-2 font-ui text-sm font-medium text-page transition-opacity hover:opacity-90 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                >
+                  {openSession.isPending ? "\u2026" : "Open Session"}
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowSessionForm(false)}
+                className="w-full text-center text-xs text-dim hover:text-ink transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+            </form>
+          )}
+        </div>
+      )}
+
       {/* Capture list area */}
-      <div className="flex flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-1 flex-col overflow-y-auto pb-40">
         {isEmpty ? (
           <div className="flex flex-1 items-center justify-center">
-            <p className="font-ui text-dim">Capture your first word</p>
+            <p className="font-ui text-dim">
+              {hasSession
+                ? "Capture your first word in this session"
+                : "Capture your first word"}
+            </p>
           </div>
         ) : (
           <ul className="px-5">
-            {captures.data.map(capture => (
+            {activeCaptures.map((capture) => (
               <CaptureEntry key={capture.id} capture={capture} />
             ))}
           </ul>
@@ -89,7 +247,7 @@ export function CaptureScreen() {
 
       {/* Inline feedback */}
       {lastParsed && (
-        <p className="rounded-button bg-accent-subtle px-3 py-2 text-sm text-accent fixed bottom-32 left-3 right-3 border border-dim">
+        <p className="fixed bottom-32 left-3 right-3 rounded-button border border-dim bg-accent-subtle px-3 py-2 text-sm text-accent">
           Captured: {lastParsed}
         </p>
       )}
@@ -100,12 +258,12 @@ export function CaptureScreen() {
       )}
 
       {/* Capture input */}
-      <div className="border-t border-divider bg-surface py-3 px-5 w-full fixed bottom-14">
+      <div className="fixed bottom-14 w-full border-t border-divider bg-surface px-5 py-3">
         <form onSubmit={handleSubmit} className="flex gap-2">
           <input
             type="text"
             value={rawText}
-            onChange={e => setRawText(e.target.value)}
+            onChange={(e) => setRawText(e.target.value)}
             placeholder="Capture a word or phrase..."
             disabled={createCapture.isPending}
             className="min-w-0 flex-1 rounded-button border border-divider bg-surface px-3 py-2 font-ui text-ink placeholder:text-dim placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"


### PR DESCRIPTION
Closes #4

## What

Session lifecycle: open a session with a source title and type, capture items within it, close the session explicitly. Only one active session at a time. The Capture screen shows two states — no session (one-off input + prompt to start a session) and active session (source header, session captures, input at bottom). One-off captures still work when no session is active.

## Changes

### Schema
- `Session` model: added `type` (book/video/article) and `closedAt` (null = active)

### Backend
- `SessionService`: `open()`, `close()`, `getActive()` with single-active-session enforcement
- `CaptureService`: `create()` now accepts optional `sessionId`; new `listSession()`
- tRPC router: `session.open`, `session.close`, `session.getActive`, `capture.listSession`
- 7 new integration tests (18 total, all passing)

### Frontend
- `CaptureScreen`: dual-state rendering with session header, close button, start-session form, and session-scoped capture listing
- All 7 existing UI tests continue to pass