### PR TITLE
feat: enrichment prompt templates

### DIFF
--- a/packages/server/prisma/migrations/20260614125153_add_session_enrichment_prompt_template/migration.sql
+++ b/packages/server/prisma/migrations/20260614125153_add_session_enrichment_prompt_template/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "enrichmentPromptTemplate" TEXT;

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -37,10 +37,11 @@ model Source {
 }
 
 model Session {
-  id        Int       @id @default(autoincrement())
-  sourceId  Int
-  createdAt DateTime  @default(now())
-  closedAt  DateTime?
+  id                        Int       @id @default(autoincrement())
+  sourceId                  Int
+  enrichmentPromptTemplate  String?
+  createdAt                 DateTime  @default(now())
+  closedAt                  DateTime?
 
   source   Source    @relation(fields: [sourceId], references: [id])
   captures Capture[]

--- a/packages/server/src/__tests__/enrichment-pipeline.test.ts
+++ b/packages/server/src/__tests__/enrichment-pipeline.test.ts
@@ -182,4 +182,27 @@ describe("EnrichmentPipeline", () => {
     const options = mockComplete.mock.calls[0][1];
     expect(options.tier).toBe("premium");
   });
+
+  it("uses the provided prompt template when constructing the prompt", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentResponse());
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    const pipeline = new EnrichmentPipeline(mockLLM);
+
+    await pipeline.enrich({
+      capture: {
+        item: "revere",
+        locator: null,
+        rawText: "revere",
+      },
+      source: null,
+      existingEntries: [],
+      template: "Custom template for {{item}}",
+    });
+
+    const promptArg = mockComplete.mock.calls[0][0] as string;
+    expect(promptArg).toBe("Custom template for revere");
+  });
 });

--- a/packages/server/src/__tests__/enrichment-prompt-builder.test.ts
+++ b/packages/server/src/__tests__/enrichment-prompt-builder.test.ts
@@ -4,6 +4,59 @@ import { EnrichmentPromptBuilder } from "../services/enrichment/enrichment-promp
 describe("EnrichmentPromptBuilder", () => {
   const builder = new EnrichmentPromptBuilder();
 
+  it("uses the default template when no session override is provided", () => {
+    const prompt = builder.build({
+      item: "serendipity",
+      source: { name: "Moby Dick", type: "book" },
+      locator: "chapter 12, page 45",
+      existingEntries: ["whale", "ship", "ocean"],
+    });
+
+    expect(prompt).toContain('Enrich the following item: "serendipity"');
+    expect(prompt).toContain('Source: "Moby Dick" (book)');
+    expect(prompt).toContain("Locator: chapter 12, page 45");
+    expect(prompt).toContain("Existing word bank entries for context:");
+    expect(prompt).toContain("- whale");
+    expect(prompt).toContain("- ship");
+    expect(prompt).toContain("- ocean");
+  });
+
+  it("uses a custom session override template when provided", () => {
+    const prompt = builder.build({
+      item: "harpoon",
+      source: { name: "Moby Dick", type: "book" },
+      locator: "chapter 3, page 15",
+      existingEntries: ["whale", "ship", "ocean"],
+      template:
+        'Study "{{item}}" from {{sourceName}} ({{sourceType}}) at {{locator}}. Known entries:\n{{existingEntries}}',
+    });
+
+    expect(prompt).toContain(
+      'Study "harpoon" from Moby Dick (book) at chapter 3, page 15.',
+    );
+    expect(prompt).toContain("Known entries:");
+    expect(prompt).toContain("- whale");
+  });
+
+  it("pre-filled session override with the default template produces the same prompt as no override", () => {
+    const defaultOutput = builder.build({
+      item: "ephemeral",
+      source: null,
+      locator: null,
+      existingEntries: [],
+    });
+
+    const preFilledOutput = builder.build({
+      item: "ephemeral",
+      source: null,
+      locator: null,
+      existingEntries: [],
+      template: EnrichmentPromptBuilder.DEFAULT_TEMPLATE,
+    });
+
+    expect(preFilledOutput).toBe(defaultOutput);
+  });
+
   it("includes item, source metadata, and locator in the prompt", () => {
     const prompt = builder.build({
       item: "serendipity",

--- a/packages/server/src/__tests__/prompt-template.test.ts
+++ b/packages/server/src/__tests__/prompt-template.test.ts
@@ -1,0 +1,86 @@
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "../generated/prisma/client.js";
+import { appRouter } from "../router.js";
+import { EnrichmentPromptBuilder } from "../services/enrichment/enrichment-prompt-builder.js";
+import type { LLMClient } from "../services/llm-client.js";
+import { PromptTemplateService } from "../services/prompt-template.js";
+
+const mockLLM = { complete: vi.fn() } as unknown as LLMClient;
+
+describe("PromptTemplateService", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.appMeta.deleteMany({
+      where: { key: "default_enrichment_prompt_template" },
+    });
+  });
+
+  it("returns the builder default when no global default is stored", async () => {
+    const result = await PromptTemplateService.getDefault(prisma);
+
+    expect(result).toBe(EnrichmentPromptBuilder.DEFAULT_TEMPLATE);
+  });
+
+  it("stores and returns a custom global default", async () => {
+    await PromptTemplateService.setDefault(
+      "Custom global template {{item}}",
+      prisma,
+    );
+
+    const result = await PromptTemplateService.getDefault(prisma);
+
+    expect(result).toBe("Custom global template {{item}}");
+  });
+
+  it("updates an existing global default", async () => {
+    await PromptTemplateService.setDefault("First version", prisma);
+    await PromptTemplateService.setDefault("Second version", prisma);
+
+    const result = await PromptTemplateService.getDefault(prisma);
+
+    expect(result).toBe("Second version");
+  });
+});
+
+describe("promptTemplate router", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.appMeta.deleteMany({
+      where: { key: "default_enrichment_prompt_template" },
+    });
+  });
+
+  it("getDefault returns the builder default when nothing is stored", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const result = await caller.promptTemplate.getDefault();
+
+    expect(result).toBe(EnrichmentPromptBuilder.DEFAULT_TEMPLATE);
+  });
+
+  it("setDefault persists a custom template", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    await caller.promptTemplate.setDefault({ template: "Router template" });
+    const result = await caller.promptTemplate.getDefault();
+
+    expect(result).toBe("Router template");
+  });
+});

--- a/packages/server/src/__tests__/session.test.ts
+++ b/packages/server/src/__tests__/session.test.ts
@@ -92,6 +92,31 @@ describe("session.open mutation", () => {
     });
   });
 
+  it("keeps the per-session template unchanged when the global default changes", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    await caller.promptTemplate.setDefault({ template: "Original global" });
+    const session = await caller.session.open({
+      name: "Immutable Session",
+      type: "book",
+      enrichmentPromptTemplate: "Original global",
+    });
+
+    await caller.promptTemplate.setDefault({ template: "New global" });
+
+    const found = await prisma.session.findUnique({
+      where: { id: session.id },
+    });
+    expect(found?.enrichmentPromptTemplate).toBe("Original global");
+
+    // Cleanup
+    await prisma.session.delete({ where: { id: session.id } });
+    await prisma.source.deleteMany({ where: { name: "Immutable Session" } });
+    await prisma.appMeta.deleteMany({
+      where: { key: "default_enrichment_prompt_template" },
+    });
+  });
+
   it("throws when another session is already active", async () => {
     const caller = appRouter.createCaller({ prisma, llm: mockLLM });
 

--- a/packages/server/src/__tests__/session.test.ts
+++ b/packages/server/src/__tests__/session.test.ts
@@ -41,6 +41,7 @@ describe("session.open mutation", () => {
     expect(result).toMatchObject({
       source: { name: "Moby Dick", type: "book" },
       closedAt: null,
+      enrichmentPromptTemplate: null,
     });
     expect(result.sourceId).toBeTypeOf("number");
 
@@ -52,6 +53,7 @@ describe("session.open mutation", () => {
     expect(found).toMatchObject({
       source: { name: "Moby Dick", type: "book" },
       closedAt: null,
+      enrichmentPromptTemplate: null,
     });
 
     // Verify a Source record was created
@@ -64,6 +66,30 @@ describe("session.open mutation", () => {
     // Cleanup
     await prisma.session.delete({ where: { id: result.id } });
     await prisma.source.deleteMany({ where: { name: "Moby Dick" } });
+  });
+
+  it("stores a per-session enrichment prompt template when provided", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const template = "Session-specific template for {{item}}";
+    const result = await caller.session.open({
+      name: "Session Template Book",
+      type: "book",
+      enrichmentPromptTemplate: template,
+    });
+
+    expect(result.enrichmentPromptTemplate).toBe(template);
+
+    const found = await prisma.session.findUnique({
+      where: { id: result.id },
+    });
+    expect(found?.enrichmentPromptTemplate).toBe(template);
+
+    // Cleanup
+    await prisma.session.delete({ where: { id: result.id } });
+    await prisma.source.deleteMany({
+      where: { name: "Session Template Book" },
+    });
   });
 
   it("throws when another session is already active", async () => {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { AppService } from "./services/app.js";
 import { CaptureService } from "./services/capture.js";
 import { EnrichmentService } from "./services/enrichment/enrichment-service.js";
+import { PromptTemplateService } from "./services/prompt-template.js";
 import { ReviewService } from "./services/review.js";
 import { SessionService } from "./services/session.js";
 import { SourceService } from "./services/source.js";
@@ -19,6 +20,16 @@ const t = initTRPC.context<AppContext>().create();
 export const appRouter = t.router({
   app: t.router({
     status: t.procedure.query(() => AppService.status()),
+  }),
+  promptTemplate: t.router({
+    getDefault: t.procedure.query(async ({ ctx }) =>
+      PromptTemplateService.getDefault(ctx.prisma),
+    ),
+    setDefault: t.procedure
+      .input(z.object({ template: z.string() }))
+      .mutation(async ({ input, ctx }) =>
+        PromptTemplateService.setDefault(input.template, ctx.prisma),
+      ),
   }),
   session: t.router({
     open: t.procedure

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -37,10 +37,16 @@ export const appRouter = t.router({
         z.object({
           name: z.string().min(1),
           type: z.enum(["book", "video", "article"]),
+          enrichmentPromptTemplate: z.string().optional(),
         }),
       )
       .mutation(async ({ input, ctx }) =>
-        SessionService.open(input.name, input.type, ctx.prisma),
+        SessionService.open(
+          input.name,
+          input.type,
+          input.enrichmentPromptTemplate,
+          ctx.prisma,
+        ),
       ),
     close: t.procedure.mutation(async ({ ctx }) => {
       const session = await SessionService.close(ctx.prisma);

--- a/packages/server/src/services/enrichment/enrichment-pipeline.ts
+++ b/packages/server/src/services/enrichment/enrichment-pipeline.ts
@@ -64,6 +64,7 @@ export interface EnrichParams {
   };
   source?: { name: string; type: string } | null;
   existingEntries: string[];
+  template?: string | null;
 }
 
 export class EnrichmentPipeline {
@@ -84,6 +85,7 @@ export class EnrichmentPipeline {
       source: params.source,
       locator: params.capture.locator,
       existingEntries: params.existingEntries,
+      template: params.template,
     });
 
     const response = await this.llm.complete(prompt, {

--- a/packages/server/src/services/enrichment/enrichment-prompt-builder.ts
+++ b/packages/server/src/services/enrichment/enrichment-prompt-builder.ts
@@ -1,31 +1,44 @@
+export const DEFAULT_ENRICHMENT_PROMPT_TEMPLATE = `Enrich the following item: "{{item}}"
+
+{{source}}{{locatorBlock}}{{existingEntriesBlock}}`;
+
 export interface EnrichmentPromptParams {
   item: string;
   source?: { name: string; type: string } | null;
   locator?: string | null;
   existingEntries: string[];
+  template?: string | null;
 }
 
 export class EnrichmentPromptBuilder {
+  static DEFAULT_TEMPLATE = DEFAULT_ENRICHMENT_PROMPT_TEMPLATE;
+
   build(params: EnrichmentPromptParams): string {
-    const { item, source, locator, existingEntries } = params;
+    const { item, source, locator, existingEntries, template } = params;
 
-    let prompt = `Enrich the following item: "${item}"\n\n`;
+    const tpl = template ?? DEFAULT_ENRICHMENT_PROMPT_TEMPLATE;
 
-    if (source) {
-      prompt += `Source: "${source.name}" (${source.type})\n`;
-    }
+    const entriesList =
+      existingEntries.length > 0
+        ? existingEntries.map((entry) => `- ${entry}`).join("\n")
+        : "";
 
-    if (locator) {
-      prompt += `Locator: ${locator}\n`;
-    }
+    const sourceBlock = source
+      ? `Source: "${source.name}" (${source.type})\n`
+      : "";
+    const locatorBlock = locator ? `Locator: ${locator}\n` : "";
+    const existingEntriesBlock = entriesList
+      ? `\nExisting word bank entries for context:\n${entriesList}\n`
+      : "";
 
-    if (existingEntries.length > 0) {
-      prompt += `\nExisting word bank entries for context:\n`;
-      for (const entry of existingEntries) {
-        prompt += `- ${entry}\n`;
-      }
-    }
-
-    return prompt;
+    return tpl
+      .replaceAll("{{item}}", item)
+      .replaceAll("{{source}}", sourceBlock)
+      .replaceAll("{{sourceName}}", source?.name ?? "")
+      .replaceAll("{{sourceType}}", source?.type ?? "")
+      .replaceAll("{{locator}}", locator ?? "")
+      .replaceAll("{{locatorBlock}}", locatorBlock)
+      .replaceAll("{{existingEntries}}", entriesList)
+      .replaceAll("{{existingEntriesBlock}}", existingEntriesBlock);
   }
 }

--- a/packages/server/src/services/enrichment/enrichment-service.ts
+++ b/packages/server/src/services/enrichment/enrichment-service.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "../../generated/prisma/client.js";
 import type { LLMClient } from "../llm-client.js";
+import { PromptTemplateService } from "../prompt-template.js";
 import { EnrichmentPipeline } from "./enrichment-pipeline.js";
 
 export const EnrichmentService = {
@@ -74,6 +75,10 @@ export const EnrichmentService = {
 
     if (!session) return;
 
+    const template =
+      session.enrichmentPromptTemplate ??
+      (await PromptTemplateService.getDefault(prisma));
+
     const captures = await prisma.capture.findMany({
       where: { sessionId },
     });
@@ -100,6 +105,7 @@ export const EnrichmentService = {
             },
             source: session.source,
             existingEntries: existingItemNames,
+            template,
           }),
         ),
       );
@@ -150,6 +156,9 @@ export const EnrichmentService = {
       if (!capture) return;
 
       const source = capture.session?.source ?? null;
+      const template =
+        capture.session?.enrichmentPromptTemplate ??
+        (await PromptTemplateService.getDefault(prisma));
 
       let existingItemNames: string[] = [];
       if (source) {
@@ -168,6 +177,7 @@ export const EnrichmentService = {
         },
         source,
         existingEntries: existingItemNames,
+        template,
       });
 
       // All entries enter Review as pending_review — the user decides.

--- a/packages/server/src/services/prompt-template.ts
+++ b/packages/server/src/services/prompt-template.ts
@@ -1,0 +1,22 @@
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { EnrichmentPromptBuilder } from "./enrichment/enrichment-prompt-builder.js";
+
+export const DEFAULT_ENRICHMENT_PROMPT_TEMPLATE_KEY =
+  "default_enrichment_prompt_template";
+
+export const PromptTemplateService = {
+  async getDefault(prisma: PrismaClient): Promise<string> {
+    const meta = await prisma.appMeta.findUnique({
+      where: { key: DEFAULT_ENRICHMENT_PROMPT_TEMPLATE_KEY },
+    });
+    return meta?.value ?? EnrichmentPromptBuilder.DEFAULT_TEMPLATE;
+  },
+
+  async setDefault(value: string, prisma: PrismaClient): Promise<void> {
+    await prisma.appMeta.upsert({
+      where: { key: DEFAULT_ENRICHMENT_PROMPT_TEMPLATE_KEY },
+      create: { key: DEFAULT_ENRICHMENT_PROMPT_TEMPLATE_KEY, value },
+      update: { value },
+    });
+  },
+};

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -3,7 +3,12 @@ import type { PrismaClient } from "../generated/prisma/client.js";
 import { SourceService } from "./source.js";
 
 export const SessionService = {
-  async open(name: string, type: string, prisma: PrismaClient) {
+  async open(
+    name: string,
+    type: string,
+    enrichmentPromptTemplate: string | null | undefined,
+    prisma: PrismaClient,
+  ) {
     const active = await prisma.session.findFirst({
       where: { closedAt: null },
     });
@@ -18,7 +23,10 @@ export const SessionService = {
     const source = await SourceService.create(name, type, prisma);
 
     return prisma.session.create({
-      data: { sourceId: source.id },
+      data: {
+        sourceId: source.id,
+        enrichmentPromptTemplate: enrichmentPromptTemplate ?? null,
+      },
       include: { source: true },
     });
   },

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { trpc } from "../../trpc";
 import { CaptureInput } from "./CaptureInput";
 import { CaptureList } from "./CaptureList";
+import { PromptTemplateEditor } from "./PromptTemplateEditor";
 import { SessionForm } from "./SessionForm";
 
 export function CaptureScreen() {
   const [lastParsed, setLastParsed] = useState<string | null>(null);
   const [showSessionForm, setShowSessionForm] = useState(false);
+  const [showTemplateEditor, setShowTemplateEditor] = useState(false);
 
   const utils = trpc.useUtils();
 
@@ -20,6 +22,9 @@ export function CaptureScreen() {
     { enabled: activeSession.data != null },
   );
   const allSources = trpc.source.list.useQuery(undefined, {
+    staleTime: Infinity,
+  });
+  const defaultTemplate = trpc.promptTemplate.getDefault.useQuery(undefined, {
     staleTime: Infinity,
   });
 
@@ -45,6 +50,12 @@ export function CaptureScreen() {
       utils.session.getActive.invalidate();
       utils.source.list.invalidate();
       setShowSessionForm(false);
+    },
+  });
+
+  const setDefaultTemplate = trpc.promptTemplate.setDefault.useMutation({
+    onSuccess: () => {
+      utils.promptTemplate.getDefault.invalidate();
     },
   });
 
@@ -95,7 +106,7 @@ export function CaptureScreen() {
 
       {/* Start session prompt (no session state) */}
       {!hasSession && (
-        <div className="mx-5 mb-2">
+        <div className="mx-5 mb-2 space-y-2">
           {!showSessionForm ? (
             <button
               type="button"
@@ -107,15 +118,39 @@ export function CaptureScreen() {
           ) : (
             <SessionForm
               sources={allSources.data ?? []}
+              defaultTemplate={defaultTemplate.data}
               isPending={openSession.isPending}
-              onStart={(name, type) =>
+              onStart={(name, type, enrichmentPromptTemplate) =>
                 openSession.mutate({
                   name,
                   type: type as "book" | "video" | "article",
+                  enrichmentPromptTemplate,
                 })
               }
               onCancel={() => setShowSessionForm(false)}
             />
+          )}
+
+          {!showSessionForm && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowTemplateEditor((s) => !s)}
+                className="w-full rounded-button border border-divider px-3 py-2 text-center text-xs text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer"
+              >
+                {showTemplateEditor
+                  ? "Hide prompt template"
+                  : "Edit enrichment prompt template"}
+              </button>
+              {showTemplateEditor && (
+                <PromptTemplateEditor
+                  defaultTemplate={defaultTemplate.data}
+                  isLoading={defaultTemplate.isLoading}
+                  isPending={setDefaultTemplate.isPending}
+                  onSave={(template) => setDefaultTemplate.mutate({ template })}
+                />
+              )}
+            </>
           )}
         </div>
       )}

--- a/packages/web/src/screens/CaptureScreen/PromptTemplateEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/PromptTemplateEditor.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { TemplateTextarea } from "./TemplateTextarea";
+
+interface PromptTemplateEditorProps {
+  defaultTemplate: string | undefined;
+  isLoading: boolean;
+  isPending: boolean;
+  onSave: (template: string) => void;
+}
+
+export function PromptTemplateEditor({
+  defaultTemplate,
+  isLoading,
+  isPending,
+  onSave,
+}: PromptTemplateEditorProps) {
+  const [template, setTemplate] = useState("");
+
+  useEffect(() => {
+    if (defaultTemplate != null && template === "") {
+      setTemplate(defaultTemplate);
+    }
+  }, [defaultTemplate, template]);
+
+  const dirty = defaultTemplate != null && template !== defaultTemplate;
+
+  return (
+    <div className="space-y-2 rounded-button border border-divider bg-surface p-3">
+      <TemplateTextarea
+        label="Global enrichment prompt template"
+        value={template}
+        onChange={setTemplate}
+        disabled={isLoading || isPending}
+        placeholder="Loading default template..."
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-dim">
+          Placeholders: {"{{item}}"}, {"{{source}}"}, {"{{sourceName}}"},{" "}
+          {"{{sourceType}}"}, {"{{locator}}"}, {"{{existingEntries}}"}
+        </span>
+        <button
+          type="button"
+          onClick={() => onSave(template)}
+          disabled={isLoading || isPending || !dirty}
+          className="rounded-button bg-accent px-3 py-1.5 font-ui text-xs font-medium text-page transition-opacity hover:opacity-90 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+        >
+          {isPending ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/screens/CaptureScreen/SessionForm.tsx
+++ b/packages/web/src/screens/CaptureScreen/SessionForm.tsx
@@ -1,5 +1,6 @@
 import { useCombobox } from "downshift";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { TemplateTextarea } from "./TemplateTextarea";
 
 const SOURCE_TYPES = [
   { value: "book", label: "Book" },
@@ -15,19 +16,32 @@ interface SourceSuggestion {
 
 export function SessionForm({
   sources,
+  defaultTemplate,
   isPending,
   onStart,
   onCancel,
 }: {
   sources: SourceSuggestion[];
+  defaultTemplate?: string;
   isPending: boolean;
-  onStart: (name: string, type: string) => void;
+  onStart: (
+    name: string,
+    type: string,
+    enrichmentPromptTemplate: string,
+  ) => void;
   onCancel: () => void;
 }) {
   const [type, setType] =
     useState<(typeof SOURCE_TYPES)[number]["value"]>("book");
   const [typeLocked, setTypeLocked] = useState(false);
   const [inputItems, setInputItems] = useState<SourceSuggestion[]>([]);
+  const [template, setTemplate] = useState(defaultTemplate ?? "");
+
+  useEffect(() => {
+    if (defaultTemplate != null) {
+      setTemplate(defaultTemplate);
+    }
+  }, [defaultTemplate]);
 
   const {
     isOpen,
@@ -64,7 +78,7 @@ export function SessionForm({
     const name = (selectedItem?.name ?? inputValue ?? "").trim();
     if (!name || isPending) return;
     const resolvedType = selectedItem?.type ?? type;
-    onStart(name, resolvedType);
+    onStart(name, resolvedType, template);
   }
 
   return (
@@ -114,6 +128,14 @@ export function SessionForm({
             ))}
         </ul>
       </div>
+
+      <TemplateTextarea
+        label="Enrichment prompt template (pre-filled from global default)"
+        value={template}
+        onChange={setTemplate}
+        disabled={isPending}
+        placeholder="Loading default template..."
+      />
 
       <div className="flex gap-2">
         <select

--- a/packages/web/src/screens/CaptureScreen/SessionForm.tsx
+++ b/packages/web/src/screens/CaptureScreen/SessionForm.tsx
@@ -155,7 +155,9 @@ export function SessionForm({
         <button
           type="submit"
           disabled={
-            isPending || !(selectedItem?.name ?? inputValue ?? "").trim()
+            isPending ||
+            defaultTemplate == null ||
+            !(selectedItem?.name ?? inputValue ?? "").trim()
           }
           className="flex-1 rounded-button bg-accent px-4 py-2 font-ui text-sm font-medium text-page transition-opacity hover:opacity-90 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
         >

--- a/packages/web/src/screens/CaptureScreen/TemplateTextarea.tsx
+++ b/packages/web/src/screens/CaptureScreen/TemplateTextarea.tsx
@@ -1,0 +1,36 @@
+import { useId } from "react";
+
+interface TemplateTextareaProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function TemplateTextarea({
+  label,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+}: TemplateTextareaProps) {
+  const id = useId();
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs font-medium text-dim">
+        {label}
+      </label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={placeholder}
+        rows={6}
+        className="w-full resize-y rounded-button border border-divider bg-surface px-3 py-2 font-mono text-xs text-ink placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+      />
+    </div>
+  );
+}

--- a/packages/web/src/screens/CaptureScreen/__tests__/SessionForm.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/__tests__/SessionForm.test.tsx
@@ -1,0 +1,52 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SessionForm } from "../SessionForm";
+
+describe("SessionForm", () => {
+  it("pre-fills the enrichment prompt template from the global default", () => {
+    render(
+      <SessionForm
+        sources={[]}
+        defaultTemplate="Default template for {{item}}"
+        isPending={false}
+        onStart={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/enrichment prompt template/i)).toHaveValue(
+      "Default template for {{item}}",
+    );
+  });
+
+  it("passes the edited template when starting a session", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+
+    render(
+      <SessionForm
+        sources={[]}
+        defaultTemplate="Default template"
+        isPending={false}
+        onStart={onStart}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const sourceInput = screen.getByPlaceholderText(/source title/i);
+    const templateInput = screen.getByLabelText(/enrichment prompt template/i);
+
+    await user.type(sourceInput, "Moby Dick");
+    await user.clear(templateInput);
+    await user.type(templateInput, "Custom session template");
+    await user.click(screen.getByRole("button", { name: /open session/i }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      "Moby Dick",
+      "book",
+      "Custom session template",
+    );
+  });
+});


### PR DESCRIPTION
Closes #11

Implements a configurable enrichment prompt template system with a global default and per-session override.

### What changed
- EnrichmentPromptBuilder now accepts a custom template with placeholders.
- Global default template stored in AppMeta, editable from the Capture screen.
- Per-session override pre-filled with the global default when starting a session.
- Enrichment pipeline resolves session override → global default.
- Added Prisma migration for Session.enrichmentPromptTemplate.
- Added/updated tests for builder, pipeline, prompt template service/router, and session behavior.

### Verification
- Server tests: 56 pass
- Web tests: 9 pass
- Typecheck: clean

### Acceptance criteria
- [x] Global default enrichment prompt template stored and editable from Capture screen
- [x] Per-session override available when starting a session, pre-filled with global default
- [x] EnrichmentPromptBuilder uses the per-session template when available, falls back to global default
- [x] Changing the global default does not retroactively affect sessions with existing overrides
- [x] EnrichmentPromptBuilder unit tests