### PR TITLE
docs: enrichment context design — ADR-0007, glossary, CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,11 +85,17 @@ The parse call is cheap and high-value: the user sees "serendipity · p.45" inst
 
 **One enrichment call per Item** to start (not batched). Simpler to build, debug, and retry. Optimize later if needed.
 
-### 5. Enrichment prompt: Per-session with global default
+### 5. Enrichment system prompt: Editable base with source-level context
 
-The enrichment prompt is the heart of the system. It must be **configurable/template-based** so the user can tweak enrichment behavior (more examples, different translation register, etc.) without changing code.
+The enrichment system prompt is the heart of the system. It has two configurable layers:
 
-**Decision: Per-session override with a global default.** Most sessions use the global default template. When starting a session, the user can optionally customize the prompt for that context (e.g., technical precision for a textbook, literary register for a novel). The per-session override is pre-filled with the global default. The global default is accessible from the Capture screen.
+1. **Base system prompt** — the foundational instructions to the enrichment agent (agent role, output format, quality constraints). Editable from the Capture screen, stored globally in AppMeta. A factory default is defined in code; a reset button restores it. Applies to all captures: one-offs and session-related.
+
+2. **Enrichment Context** — optional source-scoped guidance appended to the base system prompt (e.g., "Focus on technical terminology and political concepts. Formal register."). Mapped to a **Source**, persists across **Sessions**. Set when starting a session, editable mid-session. When present, appended with a hardcoded "Additional context:" label.
+
+**Resolution chain:** `source.enrichmentContext → null` (base system prompt only). No per-session override.
+
+The per-item user prompt (what to enrich: item, source, locator, existing entries) remains hardcoded — it is not customizable. Configurability is in the system prompt (how to enrich), not the user prompt.
 
 ### 6. Review flow: Light for most, deep for flagged
 
@@ -172,7 +178,7 @@ A clean, warm, restrained aesthetic — never stark white, never pure black. Lig
 
 ### Screen architecture
 
-Three primary tabs: **Capture**, **Review**, **Word Bank**. No separate Settings screen — the enrichment prompt template lives contextually on the Capture screen.
+Three primary tabs: **Capture**, **Review**, **Word Bank**. No separate Settings screen — the base system prompt editor and enrichment context both live contextually on the Capture screen.
 
 **Capture** — the landing screen. Two states:
 

--- a/docs/UBIQUITOUS_LANGUAGE.md
+++ b/docs/UBIQUITOUS_LANGUAGE.md
@@ -18,6 +18,7 @@
 | **Source Context** | Optional text from the **Source** (chapter, subtitle file, article) that enables higher-quality **Enrichment** | Source material, source text, reference text |
 | **Locator** | A position within a **Source** — page number, chapter, timestamp, or URL fragment — provided at capture time | Position, reference, pointer |
 | **One-off** | A **Capture** made outside of any **Session**, with no **Source** association | Standalone, ad-hoc |
+| **Enrichment Context** | Optional guidance text appended to the enrichment system prompt, scoped to a **Source** (e.g., "Focus on technical terminology and political concepts. Formal register."). Persists across **Sessions** of the same **Source**. Distinct from **Source Context** — this is *how* the agent should behave, not *what* it reads. | Source context (ambiguous), prompt context, enrichment hint
 
 ## Enrichment quality
 
@@ -53,6 +54,8 @@
 - A **Capture** belongs to exactly one **Session** or is a **One-off**
 - A **Capture** may include a **Locator** (chapter, page, timestamp)
 - A **Source** may optionally have **Source Context** attached (chapter text, subtitle file, fetched article)
+- A **Source** may optionally have **Enrichment Context** — guidance text that tailors how the **Enrichment** agent behaves for that **Source** (e.g., "Focus on technical terminology")
+- **Enrichment Context** persists across **Sessions** of the same **Source**; editing it mid-session updates the **Source** and applies to future enrichments (current session and future sessions) without retroactively re-running completed ones
 - A **Capture** with **Source Context** yields higher-quality **Enrichment** than one without
 - A **Capture** becomes an **Entry** after successful **Enrichment** and **Review**
 - An **Enrichment** is assessed for **Confidence**; low **Confidence** results in a **Flag**
@@ -78,5 +81,5 @@
 
 - "Word" was used throughout the conversation to mean both a single word (e.g., "serendipity") and a multi-word phrase (e.g., "call me Ishmael"). We canonicalize both as **Item** — a word or phrase that is the subject of a **Capture** or **Entry**.
 - "Review" was used ambiguously to mean both (a) approving enriched entries and (b) SRS flashcard-style studying. We restrict **Review** to meaning (a) — the approval step. SRS flashcard review is explicitly out of scope for the initial build and should use a different term (e.g., "study" or "recall practice") when added later.
-- "Context" was used loosely to mean both (a) the surrounding text from the source material and (b) the metadata about what/where the user was reading. We split these: **Source Context** for (a) — the actual text content — and **Session** metadata for (b). The general word "context" is avoided as a domain term.
+- "Context" was used loosely to mean both (a) the surrounding text from the source material and (b) the metadata about what/where the user was reading. We split these: **Source Context** for (a) — the actual text content — and **Session** metadata for (b). The general word "context" is avoided as a domain term. **Enrichment Context** is a deliberate exception — it refers to prompt-level guidance (how the agent should behave), not text content (what the agent reads). It is always written in full as "Enrichment Context," never shortened to "context."
 - "Source" and "Source Context" are distinct. A **Source** is the material identity (title, type). **Source Context** is the optional text content that enables exact-quote enrichment. A **Capture** always has a **Source** (or is a **One-off**) but might not have **Source Context**.

--- a/docs/adr/0007-enrichment-context-appended-to-system-prompt.md
+++ b/docs/adr/0007-enrichment-context-appended-to-system-prompt.md
@@ -1,0 +1,5 @@
+# Enrichment Context is appended to the system prompt, not the user prompt
+
+The enrichment pipeline has two prompts: a **system prompt** (instructions to the LLM: *how* to enrich) and a **user prompt** (per-item data: *what* to enrich — item, source, locator, existing entries). Enrichment Context — source-scoped guidance like "Focus on technical terminology and political concepts" — is appended to the **system prompt** as an "Additional context:" section. The per-item user prompt remains hardcoded and is never customized.
+
+The original implementation of this feature (#11) customized the *user* prompt template instead. That was wrong because the context is about how the agent should behave across all items in a source, not about per-item data formatting. One-off captures receiving per-item prompt customization made no sense — they have no source context to apply. Appending to the system prompt means the guidance applies uniformly to every enrichment in a session, including one-offs that share the base system prompt.


### PR DESCRIPTION
## What

Documentation changes from a grilling session that resolved the design for two new issues:

- **#35** — Editable base system prompt
- **#36** — Source-level enrichment context

## Changes

- **CONTEXT.md** section 5: replaced the old per-session template design with the new two-layer model (editable base system prompt + source-level enrichment context)
- **CONTEXT.md** screen architecture: updated reference from "enrichment prompt template" to "base system prompt editor and enrichment context"
- **docs/UBIQUITOUS_LANGUAGE.md**: added "Enrichment Context" term (distinct from "Source Context"), updated relationships and flagged ambiguities
- **docs/adr/0007-enrichment-context-appended-to-system-prompt.md**: new ADR recording why enrichment context is appended to the system prompt, not the user prompt — so the #11 mistake isn't repeated

## Context

This is a docs-only PR cherry-picked from the `feat/11-enrichment-prompt-templates` branch. The #11 implementation code is not included — that branch and its PRs are being abandoned. Issue #11 has been closed.