### PR TITLE
feat: editable base system prompt

### DIFF
--- a/packages/server/src/__tests__/app.test.ts
+++ b/packages/server/src/__tests__/app.test.ts
@@ -1,16 +1,84 @@
-import { describe, expect, it, vi } from "vitest";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "../generated/prisma/client.js";
 import { appRouter } from "../router.js";
+import { AppService } from "../services/app.js";
+import { FACTORY_DEFAULT_SYSTEM_PROMPT } from "../services/enrichment/enrichment-pipeline.js";
 import type { LLMClient } from "../services/llm-client.js";
 
 const mockLLM = { complete: vi.fn() } as unknown as LLMClient;
-const mockPrisma =
-  {} as unknown as import("../generated/prisma/client.js").PrismaClient;
+
+const adapter = new PrismaBetterSqlite3({
+  url: "file:./prisma/test.db",
+});
+const prisma = new PrismaClient({ adapter });
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
 
 describe("app.status query", () => {
   it("returns the app name and status", async () => {
-    const caller = appRouter.createCaller({ prisma: mockPrisma, llm: mockLLM });
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
     const result = await caller.app.status();
 
     expect(result).toEqual({ name: "Kalima", status: "ok" });
+  });
+});
+
+describe("AppService base system prompt", () => {
+  const APPMETA_KEY = "enrichment.baseSystemPrompt";
+
+  async function cleanup() {
+    await prisma.appMeta.deleteMany({
+      where: { key: APPMETA_KEY },
+    });
+  }
+
+  it("returns factory default when no override is set", async () => {
+    await cleanup();
+
+    const result = await AppService.getBaseSystemPrompt(prisma);
+
+    expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+  });
+
+  it("stores and retrieves a custom system prompt", async () => {
+    await cleanup();
+
+    const customPrompt = "You are a specialized technical terms agent.";
+    await AppService.setBaseSystemPrompt(prisma, customPrompt);
+
+    const result = await AppService.getBaseSystemPrompt(prisma);
+    expect(result).toBe(customPrompt);
+
+    await cleanup();
+  });
+
+  it("overwrites the stored prompt when set again", async () => {
+    await cleanup();
+
+    await AppService.setBaseSystemPrompt(prisma, "First prompt");
+    await AppService.setBaseSystemPrompt(prisma, "Second prompt");
+
+    const result = await AppService.getBaseSystemPrompt(prisma);
+    expect(result).toBe("Second prompt");
+
+    await cleanup();
+  });
+
+  it("reset restores factory default", async () => {
+    await cleanup();
+
+    await AppService.setBaseSystemPrompt(
+      prisma,
+      "Custom that should be cleared",
+    );
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const result = await AppService.getBaseSystemPrompt(prisma);
+    expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+
+    await cleanup();
   });
 });

--- a/packages/server/src/__tests__/app.test.ts
+++ b/packages/server/src/__tests__/app.test.ts
@@ -6,8 +6,6 @@ import { AppService } from "../services/app.js";
 import { FACTORY_DEFAULT_SYSTEM_PROMPT } from "../services/enrichment/enrichment-pipeline.js";
 import type { LLMClient } from "../services/llm-client.js";
 
-const mockLLM = { complete: vi.fn() } as unknown as LLMClient;
-
 const adapter = new PrismaBetterSqlite3({
   url: "file:./prisma/test.db",
 });
@@ -16,6 +14,8 @@ const prisma = new PrismaClient({ adapter });
 afterAll(async () => {
   await prisma.$disconnect();
 });
+
+const mockLLM = { complete: vi.fn() } as unknown as LLMClient;
 
 describe("app.status query", () => {
   it("returns the app name and status", async () => {
@@ -80,5 +80,38 @@ describe("AppService base system prompt", () => {
     expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
 
     await cleanup();
+  });
+});
+
+describe("app base system prompt tRPC routes", () => {
+  it("getBaseSystemPrompt returns factory default when no override is set", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const result = await caller.app.getBaseSystemPrompt();
+    expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+  });
+
+  it("setBaseSystemPrompt stores and getBaseSystemPrompt returns the stored value", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const customPrompt = "Custom prompt via tRPC route.";
+    await caller.app.setBaseSystemPrompt({ value: customPrompt });
+
+    const result = await caller.app.getBaseSystemPrompt();
+    expect(result).toBe(customPrompt);
+
+    await AppService.resetBaseSystemPrompt(prisma);
+  });
+
+  it("resetBaseSystemPrompt clears the override and falls back to factory default", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    await caller.app.setBaseSystemPrompt({ value: "Temporary custom prompt" });
+    await caller.app.resetBaseSystemPrompt();
+
+    const result = await caller.app.getBaseSystemPrompt();
+    expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
   });
 });

--- a/packages/server/src/__tests__/app.test.ts
+++ b/packages/server/src/__tests__/app.test.ts
@@ -84,34 +84,37 @@ describe("AppService base system prompt", () => {
 });
 
 describe("app base system prompt tRPC routes", () => {
-  it("getBaseSystemPrompt returns factory default when no override is set", async () => {
+  it("getBaseSystemPrompt returns current and factoryDefault when no override is set", async () => {
     const caller = appRouter.createCaller({ prisma, llm: mockLLM });
 
     await AppService.resetBaseSystemPrompt(prisma);
 
     const result = await caller.app.getBaseSystemPrompt();
-    expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(result.current).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(result.factoryDefault).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
   });
 
-  it("setBaseSystemPrompt stores and getBaseSystemPrompt returns the stored value", async () => {
+  it("setBaseSystemPrompt stores and getBaseSystemPrompt returns the stored value as current", async () => {
     const caller = appRouter.createCaller({ prisma, llm: mockLLM });
 
     const customPrompt = "Custom prompt via tRPC route.";
     await caller.app.setBaseSystemPrompt({ value: customPrompt });
 
     const result = await caller.app.getBaseSystemPrompt();
-    expect(result).toBe(customPrompt);
+    expect(result.current).toBe(customPrompt);
+    expect(result.factoryDefault).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
 
     await AppService.resetBaseSystemPrompt(prisma);
   });
 
-  it("resetBaseSystemPrompt clears the override and falls back to factory default", async () => {
+  it("resetBaseSystemPrompt clears the override and current falls back to factory default", async () => {
     const caller = appRouter.createCaller({ prisma, llm: mockLLM });
 
     await caller.app.setBaseSystemPrompt({ value: "Temporary custom prompt" });
     await caller.app.resetBaseSystemPrompt();
 
     const result = await caller.app.getBaseSystemPrompt();
-    expect(result).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(result.current).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(result.factoryDefault).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
   });
 });

--- a/packages/server/src/__tests__/enrichment-pipeline.test.ts
+++ b/packages/server/src/__tests__/enrichment-pipeline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   EnrichmentPipeline,
   type EnrichmentResult,
+  FACTORY_DEFAULT_SYSTEM_PROMPT,
 } from "../services/enrichment/enrichment-pipeline.js";
 import type { LLMClient } from "../services/llm-client.js";
 
@@ -181,5 +182,42 @@ describe("EnrichmentPipeline", () => {
 
     const options = mockComplete.mock.calls[0][1];
     expect(options.tier).toBe("premium");
+  });
+
+  it("uses factory default system prompt when none is provided", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentResponse());
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    const pipeline = new EnrichmentPipeline(mockLLM);
+
+    await pipeline.enrich({
+      capture: { item: "test", locator: null, rawText: "test" },
+      source: null,
+      existingEntries: [],
+    });
+
+    const options = mockComplete.mock.calls[0][1];
+    expect(options.systemPrompt).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+  });
+
+  it("uses a custom system prompt when one is provided to the constructor", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentResponse());
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    const customPrompt = "You are a specialized agent for technical terms.";
+    const pipeline = new EnrichmentPipeline(mockLLM, customPrompt);
+
+    await pipeline.enrich({
+      capture: { item: "test", locator: null, rawText: "test" },
+      source: null,
+      existingEntries: [],
+    });
+
+    const options = mockComplete.mock.calls[0][1];
+    expect(options.systemPrompt).toBe(customPrompt);
   });
 });

--- a/packages/server/src/__tests__/enrichment-service.test.ts
+++ b/packages/server/src/__tests__/enrichment-service.test.ts
@@ -2,6 +2,8 @@ import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import { PrismaClient } from "../generated/prisma/client.js";
 import { appRouter } from "../router.js";
+import { AppService } from "../services/app.js";
+import { FACTORY_DEFAULT_SYSTEM_PROMPT } from "../services/enrichment/enrichment-pipeline.js";
 import { EnrichmentService } from "../services/enrichment/enrichment-service.js";
 import type { LLMClient } from "../services/llm-client.js";
 import { SourceService } from "../services/source.js";
@@ -477,5 +479,139 @@ describe("enrichment tRPC endpoints", () => {
     await prisma.source.deleteMany({
       where: { name: "Session Filter Book" },
     });
+  });
+});
+
+describe("EnrichmentService uses stored base system prompt", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const enrichmentJson = JSON.stringify({
+    definition: "A test definition",
+    translationArabic: "اختبار",
+    nuance: "Test nuance",
+    examples: ["Example 1", "Example 2"],
+    tags: ["test"],
+    relatedEntries: [],
+    confidence: "high",
+  });
+
+  it("enrichSessionCaptures passes the stored system prompt to the LLM", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    const customPrompt = "You are a specialized technical terms agent.";
+    await AppService.setBaseSystemPrompt(prisma, customPrompt);
+
+    const source = await SourceService.create(
+      "Stored Prompt Session Book",
+      "book",
+      prisma,
+    );
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    await prisma.capture.create({
+      data: {
+        rawText: "harpoon",
+        item: "harpoon",
+        sessionId: session.id,
+      },
+    });
+
+    await EnrichmentService.createPlaceholderEntries(session.id, prisma);
+    await EnrichmentService.enrichSessionCaptures(session.id, prisma, mockLLM);
+
+    const options = mockComplete.mock.calls[0][1];
+    expect(options.systemPrompt).toBe(customPrompt);
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.source.deleteMany({
+      where: { name: "Stored Prompt Session Book" },
+    });
+    await AppService.resetBaseSystemPrompt(prisma);
+  });
+
+  it("enrichSessionCaptures falls back to factory default when no override is set", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const source = await SourceService.create(
+      "Factory Default Session Book",
+      "book",
+      prisma,
+    );
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    await prisma.capture.create({
+      data: {
+        rawText: "harpoon",
+        item: "harpoon",
+        sessionId: session.id,
+      },
+    });
+
+    await EnrichmentService.createPlaceholderEntries(session.id, prisma);
+    await EnrichmentService.enrichSessionCaptures(session.id, prisma, mockLLM);
+
+    const options = mockComplete.mock.calls[0][1];
+    expect(options.systemPrompt).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.source.deleteMany({
+      where: { name: "Factory Default Session Book" },
+    });
+  });
+
+  it("enrichCapture passes the stored system prompt to the LLM", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    const customPrompt = "You are a specialized agent for one-off captures.";
+    await AppService.setBaseSystemPrompt(prisma, customPrompt);
+
+    const capture = await prisma.capture.create({
+      data: { rawText: "ephemeral", item: "ephemeral" },
+    });
+    await prisma.entry.create({
+      data: {
+        captureId: capture.id,
+        status: "processing",
+        definition: "",
+        translationArabic: "",
+        nuance: "",
+        examples: "[]",
+        tags: "[]",
+        relatedEntries: "[]",
+      },
+    });
+
+    await EnrichmentService.enrichCapture(capture.id, prisma, mockLLM);
+
+    const options = mockComplete.mock.calls[0][1];
+    expect(options.systemPrompt).toBe(customPrompt);
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+    await AppService.resetBaseSystemPrompt(prisma);
   });
 });

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -2,6 +2,7 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { AppService } from "./services/app.js";
 import { CaptureService } from "./services/capture.js";
+import { FACTORY_DEFAULT_SYSTEM_PROMPT } from "./services/enrichment/enrichment-pipeline.js";
 import { EnrichmentService } from "./services/enrichment/enrichment-service.js";
 import { ReviewService } from "./services/review.js";
 import { SessionService } from "./services/session.js";
@@ -19,9 +20,10 @@ const t = initTRPC.context<AppContext>().create();
 export const appRouter = t.router({
   app: t.router({
     status: t.procedure.query(() => AppService.status()),
-    getBaseSystemPrompt: t.procedure.query(async ({ ctx }) =>
-      AppService.getBaseSystemPrompt(ctx.prisma),
-    ),
+    getBaseSystemPrompt: t.procedure.query(async ({ ctx }) => ({
+      current: await AppService.getBaseSystemPrompt(ctx.prisma),
+      factoryDefault: FACTORY_DEFAULT_SYSTEM_PROMPT,
+    })),
     setBaseSystemPrompt: t.procedure
       .input(z.object({ value: z.string().min(1) }))
       .mutation(async ({ input, ctx }) =>

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -19,6 +19,17 @@ const t = initTRPC.context<AppContext>().create();
 export const appRouter = t.router({
   app: t.router({
     status: t.procedure.query(() => AppService.status()),
+    getBaseSystemPrompt: t.procedure.query(async ({ ctx }) =>
+      AppService.getBaseSystemPrompt(ctx.prisma),
+    ),
+    setBaseSystemPrompt: t.procedure
+      .input(z.object({ value: z.string().min(1) }))
+      .mutation(async ({ input, ctx }) =>
+        AppService.setBaseSystemPrompt(ctx.prisma, input.value),
+      ),
+    resetBaseSystemPrompt: t.procedure.mutation(async ({ ctx }) =>
+      AppService.resetBaseSystemPrompt(ctx.prisma),
+    ),
   }),
   session: t.router({
     open: t.procedure

--- a/packages/server/src/services/app.ts
+++ b/packages/server/src/services/app.ts
@@ -1,5 +1,45 @@
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { FACTORY_DEFAULT_SYSTEM_PROMPT } from "./enrichment/enrichment-pipeline.js";
+
+const BASE_SYSTEM_PROMPT_KEY = "enrichment.baseSystemPrompt";
+
 export const AppService = {
   status() {
     return { name: "Kalima" as const, status: "ok" as const };
+  },
+
+  /**
+   * Returns the base system prompt — the stored override if one exists,
+   * otherwise the factory default.
+   */
+  async getBaseSystemPrompt(prisma: PrismaClient): Promise<string> {
+    const row = await prisma.appMeta.findUnique({
+      where: { key: BASE_SYSTEM_PROMPT_KEY },
+    });
+    return row?.value ?? FACTORY_DEFAULT_SYSTEM_PROMPT;
+  },
+
+  /**
+   * Stores (or replaces) the base system prompt override in AppMeta.
+   */
+  async setBaseSystemPrompt(
+    prisma: PrismaClient,
+    value: string,
+  ): Promise<void> {
+    await prisma.appMeta.upsert({
+      where: { key: BASE_SYSTEM_PROMPT_KEY },
+      update: { value },
+      create: { key: BASE_SYSTEM_PROMPT_KEY, value },
+    });
+  },
+
+  /**
+   * Removes the stored override so that getBaseSystemPrompt falls back
+   * to the factory default.
+   */
+  async resetBaseSystemPrompt(prisma: PrismaClient): Promise<void> {
+    await prisma.appMeta.deleteMany({
+      where: { key: BASE_SYSTEM_PROMPT_KEY },
+    });
   },
 };

--- a/packages/server/src/services/enrichment/enrichment-pipeline.ts
+++ b/packages/server/src/services/enrichment/enrichment-pipeline.ts
@@ -46,7 +46,7 @@ const ENRICHMENT_SCHEMA = {
   additionalProperties: false,
 } as const;
 
-const SYSTEM_PROMPT = `You are a word bank enrichment agent. For the given item, produce:
+export const FACTORY_DEFAULT_SYSTEM_PROMPT = `You are a word bank enrichment agent. For the given item, produce:
 - definition: a context-appropriate meaning
 - translationArabic: the Arabic equivalent in Arabic script only (no transliteration, no pronunciation guides)
 - nuance: a note on subtle shades of meaning
@@ -69,10 +69,15 @@ export interface EnrichParams {
 export class EnrichmentPipeline {
   private llm: LLMClient;
   private promptBuilder: EnrichmentPromptBuilder;
+  private systemPrompt: string;
 
-  constructor(llm: LLMClient) {
+  constructor(
+    llm: LLMClient,
+    systemPrompt: string = FACTORY_DEFAULT_SYSTEM_PROMPT,
+  ) {
     this.llm = llm;
     this.promptBuilder = new EnrichmentPromptBuilder();
+    this.systemPrompt = systemPrompt;
   }
 
   async enrich(
@@ -89,7 +94,7 @@ export class EnrichmentPipeline {
     const response = await this.llm.complete(prompt, {
       tier,
       schema: ENRICHMENT_SCHEMA,
-      systemPrompt: SYSTEM_PROMPT,
+      systemPrompt: this.systemPrompt,
     });
 
     const result = JSON.parse(response) as EnrichmentResult;

--- a/packages/server/src/services/enrichment/enrichment-service.ts
+++ b/packages/server/src/services/enrichment/enrichment-service.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from "../../generated/prisma/client.js";
+import { AppService } from "../app.js";
 import type { LLMClient } from "../llm-client.js";
 import { EnrichmentPipeline } from "./enrichment-pipeline.js";
 
@@ -65,7 +66,8 @@ export const EnrichmentService = {
     prisma: PrismaClient,
     llm: LLMClient,
   ): Promise<void> {
-    const pipeline = new EnrichmentPipeline(llm);
+    const systemPrompt = await AppService.getBaseSystemPrompt(prisma);
+    const pipeline = new EnrichmentPipeline(llm, systemPrompt);
 
     const session = await prisma.session.findUnique({
       where: { id: sessionId },
@@ -138,7 +140,8 @@ export const EnrichmentService = {
     llm: LLMClient,
   ): Promise<void> {
     try {
-      const pipeline = new EnrichmentPipeline(llm);
+      const systemPrompt = await AppService.getBaseSystemPrompt(prisma);
+      const pipeline = new EnrichmentPipeline(llm, systemPrompt);
 
       const capture = await prisma.capture.findUnique({
         where: { id: captureId },

--- a/packages/web/src/__tests__/system-prompt-editor.test.tsx
+++ b/packages/web/src/__tests__/system-prompt-editor.test.tsx
@@ -1,4 +1,3 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -16,6 +15,7 @@ function renderEditor(
     <SystemPromptEditor
       open={true}
       initialPrompt="You are a word bank enrichment agent."
+      factoryDefaultPrompt="You are a word bank enrichment agent."
       isPending={false}
       onClose={onClose}
       onSave={onSave}
@@ -46,16 +46,27 @@ describe("SystemPromptEditor", () => {
     expect(onSave).toHaveBeenCalledWith("Custom prompt text");
   });
 
-  it("calls onReset when Reset to Default is clicked", async () => {
-    const { user, onReset } = renderEditor();
+  it("calls onReset and resets textarea to factory default when Reset is clicked", async () => {
+    const { user, onReset } = renderEditor({
+      initialPrompt: "Custom saved prompt",
+      factoryDefaultPrompt: "You are a word bank enrichment agent.",
+    });
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, "Unsaved local edits");
 
     await user.click(screen.getByRole("button", { name: /reset/i }));
 
     expect(onReset).toHaveBeenCalled();
+    expect(textarea.value).toBe("You are a word bank enrichment agent.");
   });
 
   it("disables Save button when prompt is unchanged", async () => {
-    renderEditor({ initialPrompt: "Original prompt" });
+    renderEditor({
+      initialPrompt: "Original prompt",
+      factoryDefaultPrompt: "Original prompt",
+    });
 
     const saveButton = screen.getByRole("button", { name: /save/i });
     expect(saveButton).toBeDisabled();
@@ -67,5 +78,24 @@ describe("SystemPromptEditor", () => {
     await user.click(screen.getByRole("button", { name: /cancel/i }));
 
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("resets textarea to initial prompt when dialog is dismissed and reopened", async () => {
+    const { user, onClose } = renderEditor({
+      initialPrompt: "Stored prompt",
+      factoryDefaultPrompt: "Factory default",
+    });
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, "Unsaved edits");
+
+    // Dismiss the dialog
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+
+    // Reopen — the textarea should show the stored prompt, not stale edits
+    const reopenedTextarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(reopenedTextarea.value).toBe("Stored prompt");
   });
 });

--- a/packages/web/src/__tests__/system-prompt-editor.test.tsx
+++ b/packages/web/src/__tests__/system-prompt-editor.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SystemPromptEditor } from "../screens/CaptureScreen/SystemPromptEditor";
+
+function renderEditor(
+  props?: Partial<React.ComponentProps<typeof SystemPromptEditor>>,
+) {
+  const user = userEvent.setup();
+  const onClose = vi.fn();
+  const onSave = vi.fn();
+  const onReset = vi.fn();
+
+  render(
+    <SystemPromptEditor
+      open={true}
+      initialPrompt="You are a word bank enrichment agent."
+      isPending={false}
+      onClose={onClose}
+      onSave={onSave}
+      onReset={onReset}
+      {...props}
+    />,
+  );
+
+  return { user, onClose, onSave, onReset };
+}
+
+describe("SystemPromptEditor", () => {
+  it("renders a textarea pre-filled with the current system prompt", () => {
+    renderEditor();
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("You are a word bank enrichment agent.");
+  });
+
+  it("calls onSave with the edited prompt when Save is clicked", async () => {
+    const { user, onSave } = renderEditor();
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, "Custom prompt text");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledWith("Custom prompt text");
+  });
+
+  it("calls onReset when Reset to Default is clicked", async () => {
+    const { user, onReset } = renderEditor();
+
+    await user.click(screen.getByRole("button", { name: /reset/i }));
+
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it("disables Save button when prompt is unchanged", async () => {
+    renderEditor({ initialPrompt: "Original prompt" });
+
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const { user, onClose } = renderEditor();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -41,7 +41,6 @@ export function CaptureScreen() {
     },
   });
 
-  // Mutations
   const createCapture = trpc.capture.create.useMutation({
     onSuccess: (data) => {
       if (activeSession.data) {

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -3,10 +3,12 @@ import { trpc } from "../../trpc";
 import { CaptureInput } from "./CaptureInput";
 import { CaptureList } from "./CaptureList";
 import { SessionForm } from "./SessionForm";
+import { SystemPromptEditor } from "./SystemPromptEditor";
 
 export function CaptureScreen() {
   const [lastParsed, setLastParsed] = useState<string | null>(null);
   const [showSessionForm, setShowSessionForm] = useState(false);
+  const [showPromptEditor, setShowPromptEditor] = useState(false);
 
   const utils = trpc.useUtils();
 
@@ -21,6 +23,22 @@ export function CaptureScreen() {
   );
   const allSources = trpc.source.list.useQuery(undefined, {
     staleTime: Infinity,
+  });
+  const baseSystemPrompt = trpc.app.getBaseSystemPrompt.useQuery(undefined, {
+    enabled: showPromptEditor,
+  });
+
+  // Mutations
+  const setBaseSystemPrompt = trpc.app.setBaseSystemPrompt.useMutation({
+    onSuccess: () => {
+      utils.app.getBaseSystemPrompt.invalidate();
+      setShowPromptEditor(false);
+    },
+  });
+  const resetBaseSystemPrompt = trpc.app.resetBaseSystemPrompt.useMutation({
+    onSuccess: () => {
+      utils.app.getBaseSystemPrompt.invalidate();
+    },
   });
 
   // Mutations
@@ -64,11 +82,20 @@ export function CaptureScreen() {
       {/* Top bar */}
       <header className="flex items-center justify-between px-5 pt-4 pb-2">
         <h1 className="font-display text-lg font-bold text-ink">Capture</h1>
-        {activeCaptures.length > 0 && (
-          <span className="rounded-full bg-accent-subtle px-2 text-xs text-dim">
-            {activeCaptures.length}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {activeCaptures.length > 0 && (
+            <span className="rounded-full bg-accent-subtle px-2 text-xs text-dim">
+              {activeCaptures.length}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setShowPromptEditor(true)}
+            className="rounded-button border border-divider px-2.5 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer"
+          >
+            Prompt
+          </button>
+        </div>
       </header>
 
       {/* Session header (active session state) */}
@@ -134,6 +161,18 @@ export function CaptureScreen() {
             sessionId: activeSession.data?.id,
           })
         }
+      />
+
+      {/* System prompt editor */}
+      <SystemPromptEditor
+        open={showPromptEditor}
+        initialPrompt={baseSystemPrompt.data ?? ""}
+        isPending={
+          setBaseSystemPrompt.isPending || resetBaseSystemPrompt.isPending
+        }
+        onClose={() => setShowPromptEditor(false)}
+        onSave={(value) => setBaseSystemPrompt.mutate({ value })}
+        onReset={() => resetBaseSystemPrompt.mutate()}
       />
     </main>
   );

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -165,7 +165,8 @@ export function CaptureScreen() {
       {/* System prompt editor */}
       <SystemPromptEditor
         open={showPromptEditor}
-        initialPrompt={baseSystemPrompt.data ?? ""}
+        initialPrompt={baseSystemPrompt.data?.current ?? ""}
+        factoryDefaultPrompt={baseSystemPrompt.data?.factoryDefault ?? ""}
         isPending={
           setBaseSystemPrompt.isPending || resetBaseSystemPrompt.isPending
         }

--- a/packages/web/src/screens/CaptureScreen/SystemPromptEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/SystemPromptEditor.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function SystemPromptEditor({
   open,
@@ -18,6 +18,12 @@ export function SystemPromptEditor({
 }) {
   const [value, setValue] = useState(initialPrompt);
   const isUnchanged = value === initialPrompt;
+
+  // Sync local state when the prop changes (e.g. after reset refetches
+  // the factory default from the server).
+  useEffect(() => {
+    setValue(initialPrompt);
+  }, [initialPrompt]);
 
   function handleSave() {
     if (isUnchanged || isPending) return;

--- a/packages/web/src/screens/CaptureScreen/SystemPromptEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/SystemPromptEditor.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 export function SystemPromptEditor({
   open,
   initialPrompt,
+  factoryDefaultPrompt,
   isPending,
   onClose,
   onSave,
@@ -11,6 +12,7 @@ export function SystemPromptEditor({
 }: {
   open: boolean;
   initialPrompt: string;
+  factoryDefaultPrompt: string;
   isPending: boolean;
   onClose: () => void;
   onSave: (value: string) => void;
@@ -25,13 +27,25 @@ export function SystemPromptEditor({
     setValue(initialPrompt);
   }, [initialPrompt]);
 
+  function handleReset() {
+    setValue(factoryDefaultPrompt);
+    onReset();
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (!open) {
+      setValue(initialPrompt);
+      onClose();
+    }
+  }
+
   function handleSave() {
     if (isUnchanged || isPending) return;
     onSave(value);
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={(open) => !open && onClose()}>
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-button border border-divider bg-surface p-4 shadow-lg">
@@ -54,7 +68,7 @@ export function SystemPromptEditor({
           <div className="mt-3 flex items-center justify-between gap-2">
             <button
               type="button"
-              onClick={onReset}
+              onClick={handleReset}
               disabled={isPending}
               className="rounded-button border border-divider px-3 py-2 text-xs font-medium text-dim transition-colors hover:border-red-200 hover:text-red-600 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
             >
@@ -63,7 +77,7 @@ export function SystemPromptEditor({
             <div className="flex gap-2">
               <button
                 type="button"
-                onClick={onClose}
+                onClick={() => handleOpenChange(false)}
                 className="rounded-button border border-divider px-4 py-2 text-sm font-medium text-dim transition-colors hover:text-ink cursor-pointer"
               >
                 Cancel

--- a/packages/web/src/screens/CaptureScreen/SystemPromptEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/SystemPromptEditor.tsx
@@ -1,0 +1,79 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+
+export function SystemPromptEditor({
+  open,
+  initialPrompt,
+  isPending,
+  onClose,
+  onSave,
+  onReset,
+}: {
+  open: boolean;
+  initialPrompt: string;
+  isPending: boolean;
+  onClose: () => void;
+  onSave: (value: string) => void;
+  onReset: () => void;
+}) {
+  const [value, setValue] = useState(initialPrompt);
+  const isUnchanged = value === initialPrompt;
+
+  function handleSave() {
+    if (isUnchanged || isPending) return;
+    onSave(value);
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-button border border-divider bg-surface p-4 shadow-lg">
+          <Dialog.Title className="font-display text-base font-bold text-ink">
+            Base System Prompt
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-dim">
+            Foundational instructions to the enrichment agent.
+          </Dialog.Description>
+
+          <textarea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            disabled={isPending}
+            className="mt-3 min-h-[200px] w-full resize-y rounded-button border border-divider bg-surface px-3 py-2 font-ui text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+            // biome-ignore lint/a11y/noAutofocus: editor is the primary action when open
+            autoFocus
+          />
+
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={isPending}
+              className="rounded-button border border-divider px-3 py-2 text-xs font-medium text-dim transition-colors hover:border-red-200 hover:text-red-600 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+            >
+              Reset to Default
+            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-button border border-divider px-4 py-2 text-sm font-medium text-dim transition-colors hover:text-ink cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={isUnchanged || isPending}
+                className="rounded-button bg-accent px-4 py-2 text-sm font-medium text-page transition-opacity hover:opacity-90 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              >
+                {isPending ? "…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}


### PR DESCRIPTION
## Summary

Makes the hardcoded enrichment system prompt a stored, user-editable value in AppMeta, with a factory default fallback and a reset button. The editor is accessible from the Capture screen — no separate Settings screen.

Closes #35

## Changes

### Backend

- **`enrichment-pipeline.ts`** — The hardcoded `SYSTEM_PROMPT` is now an exported `FACTORY_DEFAULT_SYSTEM_PROMPT`. The `EnrichmentPipeline` constructor accepts an optional `systemPrompt` parameter (defaults to factory default).
- **`app.ts`** — `AppService` gains `getBaseSystemPrompt`, `setBaseSystemPrompt`, and `resetBaseSystemPrompt`. Stored in `AppMeta` under key `enrichment.baseSystemPrompt`. Factory default returned when no override is set.
- **`enrichment-service.ts`** — Both `enrichSessionCaptures` and `enrichCapture` now fetch the stored system prompt and pass it to the pipeline. One-offs and session-related enrichments both use the stored/factory-default prompt.
- **`router.ts`** — Three new tRPC procedures: `app.getBaseSystemPrompt` (query), `app.setBaseSystemPrompt` (mutation), `app.resetBaseSystemPrompt` (mutation).

### Frontend

- **`SystemPromptEditor.tsx`** — Radix Dialog with textarea (pre-filled with current prompt), Save (disabled when unchanged), Reset to Default, and Cancel buttons.
- **`CaptureScreen.tsx`** — "Prompt" button in the header opens the editor. Wired to tRPC queries/mutations.

## Acceptance criteria

- [x] Base system prompt stored in and retrieved from AppMeta
- [x] Factory default (current hardcoded `SYSTEM_PROMPT`) returned when no override is set
- [x] Reset button restores factory default
- [x] Editor accessible from the Capture screen (no separate Settings screen)
- [x] All enrichments (one-offs and session-related) use the stored/factory-default system prompt
- [x] Tests: storage/retrieval, factory default fallback, reset, enrichments use stored prompt

## Test plan

- [x] `pnpm test` — 95 server tests pass (12 new)
- [x] `pnpm --filter web test` — 12 web tests pass (5 new)
- [x] `pnpm typecheck` — clean