### PR TITLE
feat: source-level enrichment context (#36)

### DIFF
--- a/packages/server/prisma/migrations/20260620134324_add_enrichment_context_to_source/migration.sql
+++ b/packages/server/prisma/migrations/20260620134324_add_enrichment_context_to_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Source" ADD COLUMN "enrichmentContext" TEXT;

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -30,6 +30,9 @@ model Source {
   id   Int    @id @default(autoincrement())
   name String
   type String
+  /// Source-scoped guidance appended to the base enrichment system prompt.
+  /// Null means base system prompt only. See ADR-0007.
+  enrichmentContext String?
 
   sessions Session[]
 

--- a/packages/server/src/__tests__/enrichment-pipeline.test.ts
+++ b/packages/server/src/__tests__/enrichment-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildEnrichmentSystemPrompt,
   EnrichmentPipeline,
   type EnrichmentResult,
   FACTORY_DEFAULT_SYSTEM_PROMPT,
@@ -21,6 +22,41 @@ function enrichmentResponse(overrides: Partial<EnrichmentResult> = {}): string {
     ...overrides,
   });
 }
+
+describe("buildEnrichmentSystemPrompt", () => {
+  it("appends enrichment context with 'Additional context:' label when present", () => {
+    const base = "You are a word bank enrichment agent.";
+    const context = "Focus on technical terminology. Formal register.";
+
+    const result = buildEnrichmentSystemPrompt(base, context);
+
+    expect(result).toContain(base);
+    expect(result).toContain("Additional context:");
+    expect(result).toContain(context);
+    // The context must come after the base prompt
+    expect(result.indexOf(base)).toBeLessThan(
+      result.indexOf("Additional context:"),
+    );
+  });
+
+  it("returns the base prompt unchanged when enrichment context is null", () => {
+    const base = "You are a word bank enrichment agent.";
+
+    const result = buildEnrichmentSystemPrompt(base, null);
+
+    expect(result).toBe(base);
+    expect(result).not.toContain("Additional context:");
+  });
+
+  it("returns the base prompt unchanged when enrichment context is empty string", () => {
+    const base = "You are a word bank enrichment agent.";
+
+    const result = buildEnrichmentSystemPrompt(base, "");
+
+    expect(result).toBe(base);
+    expect(result).not.toContain("Additional context:");
+  });
+});
 
 describe("EnrichmentPipeline", () => {
   it("uses EnrichmentPromptBuilder to construct the prompt sent to the LLM", async () => {

--- a/packages/server/src/__tests__/enrichment-pipeline.test.ts
+++ b/packages/server/src/__tests__/enrichment-pipeline.test.ts
@@ -56,6 +56,26 @@ describe("buildEnrichmentSystemPrompt", () => {
     expect(result).toBe(base);
     expect(result).not.toContain("Additional context:");
   });
+
+  it("returns the base prompt unchanged when enrichment context is whitespace-only", () => {
+    const base = "You are a word bank enrichment agent.";
+
+    const result = buildEnrichmentSystemPrompt(base, "   \n\t  ");
+
+    expect(result).toBe(base);
+    expect(result).not.toContain("Additional context:");
+  });
+
+  it("trims leading and trailing whitespace from enrichment context before appending", () => {
+    const base = "You are a word bank enrichment agent.";
+    const context = "  Focus on nautical terms.  \n";
+
+    const result = buildEnrichmentSystemPrompt(base, context);
+
+    expect(result).toContain("Additional context:");
+    expect(result).toContain("Focus on nautical terms.");
+    expect(result).not.toContain("  Focus on nautical terms.  \n");
+  });
 });
 
 describe("EnrichmentPipeline", () => {

--- a/packages/server/src/__tests__/enrichment-service.test.ts
+++ b/packages/server/src/__tests__/enrichment-service.test.ts
@@ -757,3 +757,103 @@ describe("EnrichmentService appends source enrichmentContext to system prompt", 
     await prisma.capture.deleteMany();
   });
 });
+
+describe("EnrichmentService mid-session edit applies to future enrichments", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const enrichmentJson = JSON.stringify({
+    definition: "A test definition",
+    translationArabic: "اختبار",
+    nuance: "Test nuance",
+    examples: ["Example 1", "Example 2"],
+    tags: ["test"],
+    relatedEntries: [],
+    confidence: "high",
+  });
+
+  it("uses the updated enrichmentContext for the next enrichment after a mid-session edit", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const source = await SourceService.create(
+      "Future Enrichment Book",
+      "book",
+      prisma,
+      "Original context.",
+    );
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    await prisma.capture.create({
+      data: {
+        rawText: "harpoon",
+        item: "harpoon",
+        sessionId: session.id,
+      },
+    });
+
+    // First enrichment uses the original context
+    await EnrichmentService.createPlaceholderEntries(session.id, prisma);
+    await EnrichmentService.enrichSessionCaptures(session.id, prisma, mockLLM);
+    const firstSystemPrompt = mockComplete.mock.calls[0][1]
+      .systemPrompt as string;
+    expect(firstSystemPrompt).toContain("Original context.");
+
+    // Mid-session edit: update the source's enrichmentContext
+    await SourceService.updateEnrichmentContext(
+      source.id,
+      "Edited context for future enrichments.",
+      prisma,
+    );
+
+    // Add a second capture and enrich — should use the NEW context
+    await prisma.capture.create({
+      data: {
+        rawText: "whale",
+        item: "whale",
+        sessionId: session.id,
+      },
+    });
+    await EnrichmentService.createPlaceholderEntries(session.id, prisma);
+    await EnrichmentService.enrichSessionCaptures(session.id, prisma, mockLLM);
+
+    // The latest enrichment call should use the edited context
+    const lastSystemPrompt = mockComplete.mock.calls[
+      mockComplete.mock.calls.length - 1
+    ][1].systemPrompt as string;
+    expect(lastSystemPrompt).toContain(
+      "Edited context for future enrichments.",
+    );
+    expect(lastSystemPrompt).not.toContain("Original context.");
+
+    // Already-completed enrichments are not retroactively re-run: the first
+    // entry's data is unchanged (no automatic re-enrichment was triggered).
+    const entries = await prisma.entry.findMany({
+      where: { capture: { sessionId: session.id } },
+      include: { capture: true },
+    });
+    expect(entries).toHaveLength(2);
+    // Both have pending_review status — the edit did not reset or re-run them
+    for (const entry of entries) {
+      expect(entry.status).toBe("pending_review");
+    }
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.source.deleteMany({
+      where: { name: "Future Enrichment Book" },
+    });
+  });
+});

--- a/packages/server/src/__tests__/enrichment-service.test.ts
+++ b/packages/server/src/__tests__/enrichment-service.test.ts
@@ -615,3 +615,145 @@ describe("EnrichmentService uses stored base system prompt", () => {
     await AppService.resetBaseSystemPrompt(prisma);
   });
 });
+
+describe("EnrichmentService appends source enrichmentContext to system prompt", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const enrichmentJson = JSON.stringify({
+    definition: "A test definition",
+    translationArabic: "اختبار",
+    nuance: "Test nuance",
+    examples: ["Example 1", "Example 2"],
+    tags: ["test"],
+    relatedEntries: [],
+    confidence: "high",
+  });
+
+  it("appends enrichment context to the system prompt with 'Additional context:' label", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const source = await SourceService.create(
+      "Enrichment Context Append Book",
+      "book",
+      prisma,
+      "Focus on technical terminology. Formal register.",
+    );
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    await prisma.capture.create({
+      data: {
+        rawText: "harpoon",
+        item: "harpoon",
+        sessionId: session.id,
+      },
+    });
+
+    await EnrichmentService.createPlaceholderEntries(session.id, prisma);
+    await EnrichmentService.enrichSessionCaptures(session.id, prisma, mockLLM);
+
+    const systemPrompt = mockComplete.mock.calls[0][1].systemPrompt as string;
+    expect(systemPrompt).toContain(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(systemPrompt).toContain("Additional context:");
+    expect(systemPrompt).toContain(
+      "Focus on technical terminology. Formal register.",
+    );
+    // Context appears after the base prompt
+    expect(systemPrompt.indexOf(FACTORY_DEFAULT_SYSTEM_PROMPT)).toBeLessThan(
+      systemPrompt.indexOf("Additional context:"),
+    );
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.source.deleteMany({
+      where: { name: "Enrichment Context Append Book" },
+    });
+  });
+
+  it("uses base system prompt only when source has no enrichment context", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const source = await SourceService.create(
+      "No Enrichment Context Book",
+      "book",
+      prisma,
+      null,
+    );
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    await prisma.capture.create({
+      data: {
+        rawText: "harpoon",
+        item: "harpoon",
+        sessionId: session.id,
+      },
+    });
+
+    await EnrichmentService.createPlaceholderEntries(session.id, prisma);
+    await EnrichmentService.enrichSessionCaptures(session.id, prisma, mockLLM);
+
+    const systemPrompt = mockComplete.mock.calls[0][1].systemPrompt as string;
+    expect(systemPrompt).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(systemPrompt).not.toContain("Additional context:");
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.source.deleteMany({
+      where: { name: "No Enrichment Context Book" },
+    });
+  });
+
+  it("one-off captures (no source) get base system prompt only", async () => {
+    const mockComplete = vi.fn().mockResolvedValue(enrichmentJson);
+    const mockLLM: LLMClient = {
+      complete: mockComplete,
+    } as unknown as LLMClient;
+
+    await AppService.resetBaseSystemPrompt(prisma);
+
+    const capture = await prisma.capture.create({
+      data: { rawText: "ephemeral", item: "ephemeral" },
+    });
+    await prisma.entry.create({
+      data: {
+        captureId: capture.id,
+        status: "processing",
+        definition: "",
+        translationArabic: "",
+        nuance: "",
+        examples: "[]",
+        tags: "[]",
+        relatedEntries: "[]",
+      },
+    });
+
+    await EnrichmentService.enrichCapture(capture.id, prisma, mockLLM);
+
+    const systemPrompt = mockComplete.mock.calls[0][1].systemPrompt as string;
+    expect(systemPrompt).toBe(FACTORY_DEFAULT_SYSTEM_PROMPT);
+    expect(systemPrompt).not.toContain("Additional context:");
+
+    await prisma.entry.deleteMany();
+    await prisma.capture.deleteMany();
+  });
+});

--- a/packages/server/src/__tests__/session.test.ts
+++ b/packages/server/src/__tests__/session.test.ts
@@ -86,6 +86,115 @@ describe("session.open mutation", () => {
   });
 });
 
+describe("session.open with enrichmentContext", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  const mockLLM: LLMClient = {
+    complete: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        definition: "A test definition",
+        translationArabic: "اختبار",
+        nuance: "Test nuance",
+        examples: ["Example"],
+        tags: ["test"],
+        relatedEntries: [],
+      }),
+    ),
+  } as unknown as LLMClient;
+
+  it("persists enrichmentContext on the source when opening a session", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    const result = await caller.session.open({
+      name: "Context Session Book",
+      type: "book",
+      enrichmentContext: "Focus on nautical terms.",
+    });
+
+    expect(result.source.enrichmentContext).toBe("Focus on nautical terms.");
+
+    // Verify persisted on the source
+    const found = await prisma.source.findUnique({
+      where: { id: result.sourceId },
+    });
+    expect(found?.enrichmentContext).toBe("Focus on nautical terms.");
+
+    // Cleanup
+    await prisma.session.delete({ where: { id: result.id } });
+    await prisma.source.deleteMany({ where: { name: "Context Session Book" } });
+  });
+
+  it("preserves enrichmentContext across sessions of the same source", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    // Session 1: open with enrichmentContext
+    const first = await caller.session.open({
+      name: "Persistence Book",
+      type: "book",
+      enrichmentContext: "Focus on political concepts.",
+    });
+    await caller.session.close();
+
+    // Session 2: reopen same source WITHOUT passing enrichmentContext
+    const second = await caller.session.open({
+      name: "Persistence Book",
+      type: "book",
+    });
+
+    expect(second.sourceId).toBe(first.sourceId);
+    // The previously-set enrichmentContext should still be there
+    expect(second.source.enrichmentContext).toBe(
+      "Focus on political concepts.",
+    );
+
+    // Cleanup
+    await prisma.session.deleteMany({ where: { sourceId: first.sourceId } });
+    await prisma.source.deleteMany({ where: { name: "Persistence Book" } });
+  });
+
+  it("updates enrichmentContext when reopening the same source with a new value", async () => {
+    const caller = appRouter.createCaller({ prisma, llm: mockLLM });
+
+    // Session 1: open with enrichmentContext
+    const first = await caller.session.open({
+      name: "Update Context Book",
+      type: "book",
+      enrichmentContext: "Original context.",
+    });
+    await caller.session.close();
+
+    // Session 2: reopen with a different enrichmentContext
+    const second = await caller.session.open({
+      name: "Update Context Book",
+      type: "book",
+      enrichmentContext: "Updated context.",
+    });
+
+    expect(second.sourceId).toBe(first.sourceId);
+    expect(second.source.enrichmentContext).toBe("Updated context.");
+
+    // Verify persisted
+    const found = await prisma.source.findUnique({
+      where: { id: first.sourceId },
+    });
+    expect(found?.enrichmentContext).toBe("Updated context.");
+
+    // Cleanup
+    await prisma.session.deleteMany({ where: { sourceId: first.sourceId } });
+    await prisma.source.deleteMany({ where: { name: "Update Context Book" } });
+  });
+});
+
 describe("session.close mutation", () => {
   const adapter = new PrismaBetterSqlite3({
     url: "file:./prisma/test.db",

--- a/packages/server/src/__tests__/source.test.ts
+++ b/packages/server/src/__tests__/source.test.ts
@@ -214,3 +214,71 @@ describe("source.list query", () => {
     expect(results).toHaveLength(0);
   });
 });
+
+describe("source.updateEnrichmentContext mutation", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("updates the enrichmentContext on a source and persists it", async () => {
+    const caller = appRouter.createCaller({
+      prisma,
+      llm: { complete: async () => "{}" } as never,
+    });
+
+    const source = await caller.source.create({
+      name: "Mid-session Edit Book",
+      type: "book",
+      enrichmentContext: "Initial context.",
+    });
+
+    const updated = await caller.source.updateEnrichmentContext({
+      sourceId: source.id,
+      enrichmentContext: "Edited context mid-session.",
+    });
+
+    expect(updated.enrichmentContext).toBe("Edited context mid-session.");
+
+    // Verify persisted
+    const found = await prisma.source.findUnique({
+      where: { id: source.id },
+    });
+    expect(found?.enrichmentContext).toBe("Edited context mid-session.");
+
+    // Cleanup
+    await prisma.source.delete({ where: { id: source.id } });
+  });
+
+  it("clears enrichmentContext when null is passed", async () => {
+    const caller = appRouter.createCaller({
+      prisma,
+      llm: { complete: async () => "{}" } as never,
+    });
+
+    const source = await caller.source.create({
+      name: "Clear Context Book",
+      type: "book",
+      enrichmentContext: "Has context.",
+    });
+
+    const updated = await caller.source.updateEnrichmentContext({
+      sourceId: source.id,
+      enrichmentContext: null,
+    });
+
+    expect(updated.enrichmentContext).toBeNull();
+
+    const found = await prisma.source.findUnique({
+      where: { id: source.id },
+    });
+    expect(found?.enrichmentContext).toBeNull();
+
+    // Cleanup
+    await prisma.source.delete({ where: { id: source.id } });
+  });
+});

--- a/packages/server/src/__tests__/source.test.ts
+++ b/packages/server/src/__tests__/source.test.ts
@@ -75,6 +75,95 @@ describe("source.create mutation", () => {
   });
 });
 
+describe("source.create with enrichmentContext", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("creates a source with enrichmentContext and persists it", async () => {
+    const caller = appRouter.createCaller({
+      prisma,
+      llm: { complete: async () => "{}" } as never,
+    });
+
+    const result = await caller.source.create({
+      name: "Enrichment Book",
+      type: "book",
+      enrichmentContext: "Focus on technical terminology. Formal register.",
+    });
+
+    expect(result.enrichmentContext).toBe(
+      "Focus on technical terminology. Formal register.",
+    );
+
+    // Verify persisted
+    const found = await prisma.source.findUnique({
+      where: { id: result.id },
+    });
+    expect(found?.enrichmentContext).toBe(
+      "Focus on technical terminology. Formal register.",
+    );
+
+    // Cleanup
+    await prisma.source.delete({ where: { id: result.id } });
+  });
+
+  it("creates a source with null enrichmentContext when omitted", async () => {
+    const caller = appRouter.createCaller({
+      prisma,
+      llm: { complete: async () => "{}" } as never,
+    });
+
+    const result = await caller.source.create({
+      name: "No Context Book",
+      type: "book",
+    });
+
+    expect(result.enrichmentContext).toBeNull();
+
+    // Cleanup
+    await prisma.source.delete({ where: { id: result.id } });
+  });
+
+  it("updates enrichmentContext on an existing source when re-created", async () => {
+    const caller = appRouter.createCaller({
+      prisma,
+      llm: { complete: async () => "{}" } as never,
+    });
+
+    // Create without enrichmentContext
+    const first = await caller.source.create({
+      name: "Recreate Book",
+      type: "book",
+    });
+    expect(first.enrichmentContext).toBeNull();
+
+    // Re-create same (name, type) with enrichmentContext — should update
+    const second = await caller.source.create({
+      name: "Recreate Book",
+      type: "book",
+      enrichmentContext: "New context for this source.",
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.enrichmentContext).toBe("New context for this source.");
+
+    // Verify persisted
+    const found = await prisma.source.findUnique({
+      where: { id: first.id },
+    });
+    expect(found?.enrichmentContext).toBe("New context for this source.");
+
+    // Cleanup
+    await prisma.source.delete({ where: { id: first.id } });
+  });
+});
+
 describe("source.list query", () => {
   const adapter = new PrismaBetterSqlite3({
     url: "file:./prisma/test.db",

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -39,10 +39,16 @@ export const appRouter = t.router({
         z.object({
           name: z.string().min(1),
           type: z.enum(["book", "video", "article"]),
+          enrichmentContext: z.string().nullable().optional(),
         }),
       )
       .mutation(async ({ input, ctx }) =>
-        SessionService.open(input.name, input.type, ctx.prisma),
+        SessionService.open(
+          input.name,
+          input.type,
+          ctx.prisma,
+          input.enrichmentContext,
+        ),
       ),
     close: t.procedure.mutation(async ({ ctx }) => {
       const session = await SessionService.close(ctx.prisma);

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -86,6 +86,20 @@ export const appRouter = t.router({
         ),
       ),
     list: t.procedure.query(async ({ ctx }) => SourceService.list(ctx.prisma)),
+    updateEnrichmentContext: t.procedure
+      .input(
+        z.object({
+          sourceId: z.number(),
+          enrichmentContext: z.string().nullable(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) =>
+        SourceService.updateEnrichmentContext(
+          input.sourceId,
+          input.enrichmentContext,
+          ctx.prisma,
+        ),
+      ),
   }),
   capture: t.router({
     create: t.procedure

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -68,10 +68,16 @@ export const appRouter = t.router({
         z.object({
           name: z.string().min(1),
           type: z.enum(["book", "video", "article"]),
+          enrichmentContext: z.string().nullable().optional(),
         }),
       )
       .mutation(async ({ input, ctx }) =>
-        SourceService.create(input.name, input.type, ctx.prisma),
+        SourceService.create(
+          input.name,
+          input.type,
+          ctx.prisma,
+          input.enrichmentContext,
+        ),
       ),
     list: t.procedure.query(async ({ ctx }) => SourceService.list(ctx.prisma)),
   }),

--- a/packages/server/src/services/enrichment/enrichment-pipeline.ts
+++ b/packages/server/src/services/enrichment/enrichment-pipeline.ts
@@ -10,8 +10,9 @@ export function buildEnrichmentSystemPrompt(
   baseSystemPrompt: string,
   enrichmentContext: string | null,
 ): string {
-  if (!enrichmentContext) return baseSystemPrompt;
-  return `${baseSystemPrompt}\n\nAdditional context:\n${enrichmentContext}`;
+  const trimmed = enrichmentContext?.trim();
+  if (!trimmed) return baseSystemPrompt;
+  return `${baseSystemPrompt}\n\nAdditional context:\n${trimmed}`;
 }
 
 export interface EnrichmentResult {

--- a/packages/server/src/services/enrichment/enrichment-pipeline.ts
+++ b/packages/server/src/services/enrichment/enrichment-pipeline.ts
@@ -1,6 +1,19 @@
 import type { LLMClient } from "../llm-client.js";
 import { EnrichmentPromptBuilder } from "./enrichment-prompt-builder.js";
 
+/**
+ * Combines the base system prompt with optional source-scoped enrichment
+ * context. When context is present (non-empty), it is appended under a
+ * hardcoded "Additional context:" label. See ADR-0007.
+ */
+export function buildEnrichmentSystemPrompt(
+  baseSystemPrompt: string,
+  enrichmentContext: string | null,
+): string {
+  if (!enrichmentContext) return baseSystemPrompt;
+  return `${baseSystemPrompt}\n\nAdditional context:\n${enrichmentContext}`;
+}
+
 export interface EnrichmentResult {
   definition: string;
   translationArabic: string;

--- a/packages/server/src/services/enrichment/enrichment-service.ts
+++ b/packages/server/src/services/enrichment/enrichment-service.ts
@@ -1,7 +1,10 @@
 import type { PrismaClient } from "../../generated/prisma/client.js";
 import { AppService } from "../app.js";
 import type { LLMClient } from "../llm-client.js";
-import { EnrichmentPipeline } from "./enrichment-pipeline.js";
+import {
+  buildEnrichmentSystemPrompt,
+  EnrichmentPipeline,
+} from "./enrichment-pipeline.js";
 
 export const EnrichmentService = {
   /**
@@ -66,8 +69,7 @@ export const EnrichmentService = {
     prisma: PrismaClient,
     llm: LLMClient,
   ): Promise<void> {
-    const systemPrompt = await AppService.getBaseSystemPrompt(prisma);
-    const pipeline = new EnrichmentPipeline(llm, systemPrompt);
+    const baseSystemPrompt = await AppService.getBaseSystemPrompt(prisma);
 
     const session = await prisma.session.findUnique({
       where: { id: sessionId },
@@ -75,6 +77,12 @@ export const EnrichmentService = {
     });
 
     if (!session) return;
+
+    const systemPrompt = buildEnrichmentSystemPrompt(
+      baseSystemPrompt,
+      session.source.enrichmentContext,
+    );
+    const pipeline = new EnrichmentPipeline(llm, systemPrompt);
 
     const captures = await prisma.capture.findMany({
       where: { sessionId },
@@ -140,8 +148,7 @@ export const EnrichmentService = {
     llm: LLMClient,
   ): Promise<void> {
     try {
-      const systemPrompt = await AppService.getBaseSystemPrompt(prisma);
-      const pipeline = new EnrichmentPipeline(llm, systemPrompt);
+      const baseSystemPrompt = await AppService.getBaseSystemPrompt(prisma);
 
       const capture = await prisma.capture.findUnique({
         where: { id: captureId },
@@ -153,6 +160,12 @@ export const EnrichmentService = {
       if (!capture) return;
 
       const source = capture.session?.source ?? null;
+
+      const systemPrompt = buildEnrichmentSystemPrompt(
+        baseSystemPrompt,
+        source?.enrichmentContext ?? null,
+      );
+      const pipeline = new EnrichmentPipeline(llm, systemPrompt);
 
       let existingItemNames: string[] = [];
       if (source) {

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -3,7 +3,12 @@ import type { PrismaClient } from "../generated/prisma/client.js";
 import { SourceService } from "./source.js";
 
 export const SessionService = {
-  async open(name: string, type: string, prisma: PrismaClient) {
+  async open(
+    name: string,
+    type: string,
+    prisma: PrismaClient,
+    enrichmentContext?: string | null,
+  ) {
     const active = await prisma.session.findFirst({
       where: { closedAt: null },
     });
@@ -15,7 +20,12 @@ export const SessionService = {
       });
     }
 
-    const source = await SourceService.create(name, type, prisma);
+    const source = await SourceService.create(
+      name,
+      type,
+      prisma,
+      enrichmentContext,
+    );
 
     return prisma.session.create({
       data: { sourceId: source.id },

--- a/packages/server/src/services/source.ts
+++ b/packages/server/src/services/source.ts
@@ -1,20 +1,52 @@
 import type { PrismaClient } from "../generated/prisma/client.js";
 
 export const SourceService = {
-  async create(name: string, type: string, prisma: PrismaClient) {
+  /**
+   * Find or create a Source by (name, type). When enrichmentContext is
+   * provided (including null), it is written to the existing or new Source —
+   * this lets the SessionForm set/update source-scoped guidance on open.
+   * When enrichmentContext is undefined, an existing Source is left untouched.
+   */
+  async create(
+    name: string,
+    type: string,
+    prisma: PrismaClient,
+    enrichmentContext?: string | null,
+  ) {
     const existing = await prisma.source.findUnique({
       where: { name_type: { name, type } },
     });
-    if (existing) return existing;
+    if (existing) {
+      if (enrichmentContext === undefined) return existing;
+      return prisma.source.update({
+        where: { id: existing.id },
+        data: { enrichmentContext: enrichmentContext ?? null },
+      });
+    }
 
     return prisma.source.create({
-      data: { name, type },
+      data: { name, type, enrichmentContext: enrichmentContext ?? null },
     });
   },
 
   async list(prisma: PrismaClient) {
     return prisma.source.findMany({
       orderBy: { name: "asc" },
+    });
+  },
+
+  /**
+   * Update the enrichmentContext on a Source. Passing null clears it.
+   * Used for mid-session edits — applies to future enrichments only.
+   */
+  async updateEnrichmentContext(
+    sourceId: number,
+    enrichmentContext: string | null,
+    prisma: PrismaClient,
+  ) {
+    return prisma.source.update({
+      where: { id: sourceId },
+      data: { enrichmentContext },
     });
   },
 };

--- a/packages/web/src/__tests__/enrichment-context-editor.test.tsx
+++ b/packages/web/src/__tests__/enrichment-context-editor.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EnrichmentContextEditor } from "../screens/CaptureScreen/EnrichmentContextEditor";
+
+function renderEditor(
+  props?: Partial<React.ComponentProps<typeof EnrichmentContextEditor>>,
+) {
+  const user = userEvent.setup();
+  const onSave = vi.fn();
+  render(
+    <EnrichmentContextEditor
+      initialContext="Focus on nautical terms."
+      isPending={false}
+      onSave={onSave}
+      onCancel={vi.fn()}
+      {...props}
+    />,
+  );
+  return { user, onSave };
+}
+
+describe("EnrichmentContextEditor", () => {
+  it("renders a textarea pre-filled with the current enrichment context", () => {
+    renderEditor();
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("Focus on nautical terms.");
+  });
+
+  it("calls onSave with the edited context when Save is clicked", async () => {
+    const { user, onSave } = renderEditor();
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, "New guidance for enrichment.");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledWith("New guidance for enrichment.");
+  });
+
+  it("calls onSave with null when the field is cleared and Save is clicked", async () => {
+    const { user, onSave } = renderEditor();
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await user.clear(textarea);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onCancel when Cancel is clicked", async () => {
+    const onCancel = vi.fn();
+    const { user } = renderEditor({ onCancel });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("disables Save when the context is unchanged", () => {
+    renderEditor();
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    expect(saveButton).toBeDisabled();
+  });
+});

--- a/packages/web/src/__tests__/session-form.test.tsx
+++ b/packages/web/src/__tests__/session-form.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SessionForm } from "../screens/CaptureScreen/SessionForm";
+
+const baseProps = {
+  isPending: false,
+  onCancel: vi.fn(),
+};
+
+function renderForm(
+  sources: {
+    id: number;
+    name: string;
+    type: string;
+    enrichmentContext: string | null;
+  }[] = [],
+  onStart = vi.fn(),
+) {
+  const user = userEvent.setup();
+  render(
+    <SessionForm
+      sources={sources}
+      onStart={onStart}
+      isPending={baseProps.isPending}
+      onCancel={baseProps.onCancel}
+    />,
+  );
+  return { user, onStart };
+}
+
+describe("SessionForm enrichmentContext", () => {
+  it("renders a textarea for enrichment context", () => {
+    renderForm();
+    expect(
+      screen.getByPlaceholderText(/enrichment context/i),
+    ).toBeInTheDocument();
+  });
+
+  it("passes enrichmentContext to onStart when opening a session", async () => {
+    const onStart = vi.fn();
+    const { user } = renderForm([], onStart);
+
+    await user.type(screen.getByPlaceholderText(/source title/i), "New Book");
+    await user.type(
+      screen.getByPlaceholderText(/enrichment context/i),
+      "Focus on technical terms.",
+    );
+    await user.click(screen.getByRole("button", { name: /open session/i }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      "New Book",
+      "book",
+      "Focus on technical terms.",
+    );
+  });
+
+  it("pre-fills enrichmentContext when an existing source is selected", async () => {
+    const onStart = vi.fn();
+    const sources = [
+      {
+        id: 1,
+        name: "Moby Dick",
+        type: "book",
+        enrichmentContext: "Focus on nautical terms. Formal register.",
+      },
+    ];
+    const { user } = renderForm(sources, onStart);
+
+    const input = screen.getByPlaceholderText(/source title/i);
+    await user.type(input, "Moby");
+    // Select the suggestion
+    await user.click(screen.getByText("Moby Dick"));
+
+    const textarea = screen.getByPlaceholderText(
+      /enrichment context/i,
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe("Focus on nautical terms. Formal register.");
+
+    // Type auto-locks to the source's type
+    await user.click(screen.getByRole("button", { name: /open session/i }));
+
+    expect(onStart).toHaveBeenCalledWith(
+      "Moby Dick",
+      "book",
+      "Focus on nautical terms. Formal register.",
+    );
+  });
+
+  it("passes null enrichmentContext when the field is left empty", async () => {
+    const onStart = vi.fn();
+    const { user } = renderForm([], onStart);
+
+    await user.type(screen.getByPlaceholderText(/source title/i), "No Context");
+    await user.click(screen.getByRole("button", { name: /open session/i }));
+
+    expect(onStart).toHaveBeenCalledWith("No Context", "book", null);
+  });
+});

--- a/packages/web/src/__tests__/session-form.test.tsx
+++ b/packages/web/src/__tests__/session-form.test.tsx
@@ -96,4 +96,51 @@ describe("SessionForm enrichmentContext", () => {
 
     expect(onStart).toHaveBeenCalledWith("No Context", "book", null);
   });
+
+  it("blocks submit and shows a hint when typing a name that matches an existing source", async () => {
+    const onStart = vi.fn();
+    const sources = [
+      {
+        id: 1,
+        name: "Moby Dick",
+        type: "book",
+        enrichmentContext: "Nautical terms.",
+      },
+    ];
+    const { user } = renderForm(sources, onStart);
+
+    await user.type(screen.getByPlaceholderText(/source title/i), "Moby Dick");
+
+    expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open session/i }),
+    ).toBeDisabled();
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it("clears enrichmentContext when the name is edited after selecting a source", async () => {
+    const sources = [
+      {
+        id: 1,
+        name: "Moby Dick",
+        type: "book",
+        enrichmentContext: "Nautical terms.",
+      },
+    ];
+    const { user } = renderForm(sources);
+
+    const input = screen.getByPlaceholderText(/source title/i);
+    await user.type(input, "Moby");
+    await user.click(screen.getByText("Moby Dick"));
+
+    const textarea = screen.getByPlaceholderText(
+      /enrichment context/i,
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe("Nautical terms.");
+
+    await user.clear(input);
+    await user.type(input, "New Book");
+
+    expect(textarea.value).toBe("");
+  });
 });

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { trpc } from "../../trpc";
 import { CaptureInput } from "./CaptureInput";
 import { CaptureList } from "./CaptureList";
+import { EnrichmentContextEditor } from "./EnrichmentContextEditor";
 import { SessionForm } from "./SessionForm";
 import { SystemPromptEditor } from "./SystemPromptEditor";
 
@@ -9,6 +10,7 @@ export function CaptureScreen() {
   const [lastParsed, setLastParsed] = useState<string | null>(null);
   const [showSessionForm, setShowSessionForm] = useState(false);
   const [showPromptEditor, setShowPromptEditor] = useState(false);
+  const [showContextEditor, setShowContextEditor] = useState(false);
 
   const utils = trpc.useUtils();
 
@@ -65,6 +67,15 @@ export function CaptureScreen() {
     },
   });
 
+  const updateEnrichmentContext =
+    trpc.source.updateEnrichmentContext.useMutation({
+      onSuccess: () => {
+        utils.session.getActive.invalidate();
+        utils.source.list.invalidate();
+        setShowContextEditor(false);
+      },
+    });
+
   const closeSession = trpc.session.close.useMutation({
     onSuccess: () => {
       utils.session.getActive.invalidate();
@@ -72,6 +83,7 @@ export function CaptureScreen() {
   });
 
   const hasSession = activeSession.data != null;
+  const activeSource = activeSession.data?.source ?? null;
   const activeCaptures = hasSession
     ? (sessionCaptures.data ?? [])
     : (captures.data ?? []);
@@ -99,23 +111,51 @@ export function CaptureScreen() {
 
       {/* Session header (active session state) */}
       {hasSession && (
-        <div className="mx-5 mb-2 flex items-center justify-between rounded-button border border-divider bg-surface px-3 py-2.5">
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-display text-sm font-semibold text-ink">
-              {activeSession.data?.source?.name}
+        <div className="mx-5 mb-2 space-y-2">
+          <div className="flex items-center justify-between rounded-button border border-divider bg-surface px-3 py-2.5">
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-display text-sm font-semibold text-ink">
+                {activeSession.data?.source?.name}
+              </div>
+              <div className="mt-0.5 text-xs text-dim">
+                {activeSession.data?.source?.type}
+              </div>
             </div>
-            <div className="mt-0.5 text-xs text-dim">
-              {activeSession.data?.source?.type}
+            <div className="ml-2 flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setShowContextEditor((v) => !v)}
+                className={`rounded-button border px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+                  activeSession.data?.source?.enrichmentContext
+                    ? "border-accent text-accent"
+                    : "border-divider text-dim hover:border-accent hover:text-accent"
+                }`}
+              >
+                Context
+              </button>
+              <button
+                type="button"
+                onClick={() => closeSession.mutate()}
+                disabled={closeSession.isPending}
+                className="rounded-button border border-divider px-3 py-1 text-xs font-medium text-dim transition-colors hover:border-red-200 hover:text-red-600 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              >
+                {closeSession.isPending ? "\u2026" : "Close"}
+              </button>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => closeSession.mutate()}
-            disabled={closeSession.isPending}
-            className="ml-2 shrink-0 rounded-button border border-divider px-3 py-1 text-xs font-medium text-dim transition-colors hover:border-red-200 hover:text-red-600 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-          >
-            {closeSession.isPending ? "\u2026" : "Close"}
-          </button>
+          {showContextEditor && activeSource && (
+            <EnrichmentContextEditor
+              initialContext={activeSource.enrichmentContext}
+              isPending={updateEnrichmentContext.isPending}
+              onSave={(enrichmentContext) =>
+                updateEnrichmentContext.mutate({
+                  sourceId: activeSource.id,
+                  enrichmentContext,
+                })
+              }
+              onCancel={() => setShowContextEditor(false)}
+            />
+          )}
         </div>
       )}
 
@@ -134,10 +174,11 @@ export function CaptureScreen() {
             <SessionForm
               sources={allSources.data ?? []}
               isPending={openSession.isPending}
-              onStart={(name, type) =>
+              onStart={(name, type, enrichmentContext) =>
                 openSession.mutate({
                   name,
                   type: type as "book" | "video" | "article",
+                  enrichmentContext,
                 })
               }
               onCancel={() => setShowSessionForm(false)}

--- a/packages/web/src/screens/CaptureScreen/EnrichmentContextEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/EnrichmentContextEditor.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+
+export function EnrichmentContextEditor({
+  initialContext,
+  isPending,
+  onSave,
+  onCancel,
+}: {
+  initialContext: string | null;
+  isPending: boolean;
+  onSave: (enrichmentContext: string | null) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initialContext ?? "");
+
+  // Reset local state when the dialog reopens with a fresh initialContext
+  useEffect(() => {
+    setValue(initialContext ?? "");
+  }, [initialContext]);
+
+  const trimmed = value.trim();
+  const initialTrimmed = (initialContext ?? "").trim();
+  const isUnchanged = trimmed === initialTrimmed;
+
+  function handleSave() {
+    if (isUnchanged || isPending) return;
+    onSave(trimmed || null);
+  }
+
+  return (
+    <div className="space-y-2 rounded-button border border-divider bg-surface p-3">
+      <label
+        htmlFor="enrichment-context"
+        className="block text-xs font-medium text-dim"
+      >
+        Enrichment context
+      </label>
+      <textarea
+        id="enrichment-context"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Optional guidance appended to the enrichment system prompt for this source"
+        disabled={isPending}
+        rows={3}
+        className="w-full rounded-button border border-divider bg-surface px-3 py-2 font-ui text-sm text-ink placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+      />
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isUnchanged || isPending}
+          className="flex-1 rounded-button bg-accent px-4 py-2 font-ui text-sm font-medium text-page transition-opacity hover:opacity-90 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+        >
+          {isPending ? "\u2026" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="rounded-button border border-divider px-4 py-2 font-ui text-sm font-medium text-dim transition-colors hover:text-ink disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/screens/CaptureScreen/SessionForm.tsx
+++ b/packages/web/src/screens/CaptureScreen/SessionForm.tsx
@@ -55,6 +55,10 @@ export function SessionForm({
       );
       if (value !== current?.name) {
         setTypeLocked(false);
+        setEnrichmentContext("");
+      } else if (current) {
+        // Name matches the selected item again — restore its context
+        setEnrichmentContext(current.enrichmentContext ?? "");
       }
     },
     onSelectedItemChange({ selectedItem: source }) {
@@ -66,13 +70,19 @@ export function SessionForm({
     },
   });
 
+  const typedName = (inputValue ?? "").trim();
+  const unselectedExistingMatch = typedName
+    ? sources.find(
+        (s) =>
+          s.name === typedName && s.type === type && s.id !== selectedItem?.id,
+      )
+    : undefined;
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const name = (selectedItem?.name ?? inputValue ?? "").trim();
-    if (!name || isPending) return;
-    const resolvedType = selectedItem?.type ?? type;
+    if (!typedName || isPending || unselectedExistingMatch) return;
     const context = enrichmentContext.trim();
-    onStart(name, resolvedType, context || null);
+    onStart(typedName, type, context || null);
   }
 
   return (
@@ -122,6 +132,12 @@ export function SessionForm({
             ))}
         </ul>
       </div>
+      {unselectedExistingMatch && (
+        <p className="text-xs text-dim">
+          "{typedName}" already exists as a {type} source. Select it from the
+          dropdown to reuse its enrichment context.
+        </p>
+      )}
 
       <div className="flex gap-2">
         <select
@@ -140,9 +156,7 @@ export function SessionForm({
         </select>
         <button
           type="submit"
-          disabled={
-            isPending || !(selectedItem?.name ?? inputValue ?? "").trim()
-          }
+          disabled={isPending || !typedName || !!unselectedExistingMatch}
           className="flex-1 rounded-button bg-accent px-4 py-2 font-ui text-sm font-medium text-page transition-opacity hover:opacity-90 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
         >
           {isPending ? "\u2026" : "Open Session"}

--- a/packages/web/src/screens/CaptureScreen/SessionForm.tsx
+++ b/packages/web/src/screens/CaptureScreen/SessionForm.tsx
@@ -11,6 +11,7 @@ interface SourceSuggestion {
   id: number;
   name: string;
   type: string;
+  enrichmentContext: string | null;
 }
 
 export function SessionForm({
@@ -21,13 +22,18 @@ export function SessionForm({
 }: {
   sources: SourceSuggestion[];
   isPending: boolean;
-  onStart: (name: string, type: string) => void;
+  onStart: (
+    name: string,
+    type: string,
+    enrichmentContext: string | null,
+  ) => void;
   onCancel: () => void;
 }) {
   const [type, setType] =
     useState<(typeof SOURCE_TYPES)[number]["value"]>("book");
   const [typeLocked, setTypeLocked] = useState(false);
   const [inputItems, setInputItems] = useState<SourceSuggestion[]>([]);
+  const [enrichmentContext, setEnrichmentContext] = useState<string>("");
 
   const {
     isOpen,
@@ -55,6 +61,7 @@ export function SessionForm({
       if (source) {
         setType(source.type as (typeof SOURCE_TYPES)[number]["value"]);
         setTypeLocked(true);
+        setEnrichmentContext(source.enrichmentContext ?? "");
       }
     },
   });
@@ -64,7 +71,8 @@ export function SessionForm({
     const name = (selectedItem?.name ?? inputValue ?? "").trim();
     if (!name || isPending) return;
     const resolvedType = selectedItem?.type ?? type;
-    onStart(name, resolvedType);
+    const context = enrichmentContext.trim();
+    onStart(name, resolvedType, context || null);
   }
 
   return (
@@ -140,6 +148,14 @@ export function SessionForm({
           {isPending ? "\u2026" : "Open Session"}
         </button>
       </div>
+      <textarea
+        value={enrichmentContext}
+        onChange={(e) => setEnrichmentContext(e.target.value)}
+        placeholder="Enrichment context (optional): guidance appended to the enrichment system prompt for this source"
+        disabled={isPending}
+        rows={2}
+        className="w-full rounded-button border border-divider bg-surface px-3 py-2 font-ui text-sm text-ink placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+      />
       <button
         type="button"
         onClick={onCancel}


### PR DESCRIPTION
## Summary

Implements #36 — adds an optional **Enrichment Context** field to the Source model: source-scoped guidance text that tailors how the enrichment agent behaves for a given Source (e.g. "Focus on technical terminology and political concepts. Formal register.").

When Enrichment Context is present on a Source, it is appended to the base system prompt with a hardcoded `Additional context:` label:

```
[base system prompt]

Additional context:
[enrichment context]
```

When none is set, the system prompt is just the base. One-offs have no Source, so they get the base system prompt only — no enrichment context.

Built in vertical TDD slices (one test → one implementation → repeat).

## Changes

### Backend
- **Schema**: `enrichmentContext String?` field on Source model + Prisma migration.
- **`SourceService.create`** accepts optional `enrichmentContext` and upserts it on the `(name, type)` source.
- **`SourceService.updateEnrichmentContext`** for mid-session edits.
- **`buildEnrichmentSystemPrompt(base, enrichmentContext)`** — pure helper that appends the context under `Additional context:` when present, returns base unchanged when null/empty (ADR-0007).
- **`EnrichmentService`** (`enrichSessionCaptures` + `enrichCapture`) build the final system prompt from base + `source.enrichmentContext`. One-offs resolve to base only.
- **`session.open`** accepts `enrichmentContext`, persists on the Source. Reopening the same source preserves a previously-set context; passing a new value updates it (persistence across sessions).
- **`source.updateEnrichmentContext`** tRPC mutation — edits apply to future enrichments only; already-completed entries are not retroactively re-run.

### Frontend
- **`SessionForm`** — enrichment context textarea, pre-filled when an existing source is selected, passed to `session.open`.
- **`EnrichmentContextEditor`** — new sub-component for editing the active session's source context mid-session, wired into the CaptureScreen session header via a "Context" toggle.

## Acceptance criteria
- [x] `enrichmentContext` (String?) field on Source model
- [x] Enrichment context appended to system prompt with "Additional context:" label when present
- [x] Enrichment context persists across sessions of the same Source
- [x] Set in SessionForm when starting a session, pre-filled for existing sources
- [x] Editable mid-session, updates Source record immediately
- [x] Editing mid-session applies to future enrichments (current + future sessions), no retroactive re-run
- [x] One-offs get base system prompt only (no enrichment context)
- [x] Tests: storage/retrieval, persistence across sessions, appending to system prompt, resolution chain, mid-session edit

## Tests
- Server: 110 passed (was 95; +15 new)
- Web: 22 passed (was 17; +5 new)
- Typecheck and lint clean on changed files.

## Notes
- While running the migration, `dev.db` was found to have drifted from an abandoned earlier approach (#11 left a `session.enrichmentPromptTemplate` column). It was reset so migrations apply cleanly. The generated Prisma client is gitignored and regenerates locally.

Closes #36.