### PR TITLE
feat(server): production build pipeline (tsc build + node start)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,6 +7,8 @@
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "INTEGRATION=1 vitest run",
@@ -14,17 +16,17 @@
   },
   "dependencies": {
     "@prisma/adapter-better-sqlite3": "^7.8.0",
+    "@prisma/client": "^7.8.0",
     "@trpc/server": "^11.1.2",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",
     "express": "^5.1.0",
-    "prisma": "^7.8.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {
-    "@prisma/client": "^7.8.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.2",
+    "prisma": "^7.8.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vitest": "^3.1.3"

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -3,8 +3,9 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client"
-  output   = "../src/generated/prisma"
+  provider             = "prisma-client"
+  output               = "../src/generated/prisma"
+  importFileExtension  = "js"
 }
 
 model AppMeta {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@prisma/adapter-better-sqlite3':
         specifier: ^7.8.0
         version: 7.8.0
+      '@prisma/client':
+        specifier: ^7.8.0
+        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server':
         specifier: ^11.1.2
         version: 11.17.0(typescript@5.9.3)
@@ -41,22 +44,19 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
-      prisma:
-        specifier: ^7.8.0
-        version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       zod:
         specifier: ^3.24.3
         version: 3.25.76
     devDependencies:
-      '@prisma/client':
-        specifier: ^7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
       '@types/express':
         specifier: ^5.0.2
         version: 5.0.6
+      prisma:
+        specifier: ^7.8.0
+        version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       tsx:
         specifier: ^4.19.4
         version: 4.21.0


### PR DESCRIPTION
Closes #28.

## What

A production build pipeline for the `server` package so it can compile from TypeScript to JavaScript and serve the full app (tRPC API + frontend static files) from compiled output — instead of only running via `tsx watch`.

## Changes

**`packages/server/package.json`**
- Add `"build": "tsc"` (compiles `src/` → `dist/`) and `"start": "node dist/index.js"` scripts.
- Move `@prisma/client` from `devDependencies` → `dependencies` (runtime dep: the generated Prisma client imports `@prisma/client/runtime/client`).
- Move `prisma` CLI from `dependencies` → `devDependencies` (only needed for `prisma generate` / migrations).

**`packages/server/prisma/schema.prisma`**
- Set `importFileExtension = "js"` on the `prisma-client` generator.

### Why `importFileExtension = "js"` (the non-obvious part)

`pnpm --filter server build` compiled cleanly, but `node dist/index.js` crashed at startup with `ERR_MODULE_NOT_FOUND`. Root cause: Prisma 7 generates its client as TypeScript with **extensionless** relative imports (`./internal/class`). These resolve fine under `tsx` (esbuild bundler resolution) and under `tsc --noEmit` (`moduleResolution: bundler`), but after `tsc` emits `dist/` the imports stay extensionless and **Node's native ESM loader requires explicit extensions** (`"type": "module"`). `tsc` does not rewrite import specifiers on emit.

Setting `importFileExtension = "js"` makes the generated imports use `.js` (`./internal/class.js`). After `tsc` emits `dist/generated/**/*.js`, Node resolves them; and `tsx` / `tsc --noEmit` still map `.js` → `.ts` via bundler resolution. **One setting, valid in all three execution modes.**

## Verification

- `pnpm --filter server build` → 0 errors.
- `pnpm --filter web build` → produces `packages/web/dist/` (index.html + assets).
- `node packages/server/dist/index.js` starts; verified end-to-end (no `tsx` running):
  - static `index.html`, JS asset, CSS asset → `200`
  - SPA fallback (`/some/deep/route`) → `200`
  - tRPC `app.status`, `source.list`, `capture.list` → `200` + real JSON data
  - unknown procedure → `404`
- `dev` (tsx) still works; `tsc --noEmit` typecheck passes; all **112 server tests pass**.

## Acceptance criteria

- [x] `@prisma/client` moved from `devDependencies` to `dependencies`
- [x] `prisma` CLI moved from `dependencies` to `devDependencies`
- [x] `"build": "tsc"` script compiles `src/` → `dist/`
- [x] `"start": "node dist/index.js"` script
- [x] `pnpm --filter server build` completes without errors
- [x] `node packages/server/dist/index.js` starts, tRPC endpoints respond, frontend static files served
- [x] `pnpm --filter web build` produces `dist/` that the server successfully serves