### PR TITLE
PM2 Deployment Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ pnpm test          # run server tests
 
 ## Production
 
-Build the frontend, then run the server with production env vars:
+Kalima runs as a single PM2-managed process that serves the tRPC API and the
+built frontend (with SPA fallback) from one Express server, backed by a single
+SQLite file. Full deploy runbook (PM2, auto-start on boot, log rotation, LAN +
+Tailscale access): **[docs/deployment.md](./docs/deployment.md)**.
+
+Quick start on an Ubuntu home server:
 
 ```bash
-cd packages/web && pnpm build
-DATABASE_URL=file:/data/kalima.db STATIC_DIR=packages/web/dist node packages/server/dist/index.js
+./scripts/deploy.sh   # install -> prisma migrate deploy -> build server/web -> pm2 start
 ```
 
 ## Project structure

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,178 @@
+# Kalima deployment — Ubuntu home server + PM2
+
+This is the human runbook for issue #29. The configuration files
+(`ecosystem.config.js`, `scripts/deploy.sh`) can be prepared ahead of time, but
+**the actual deployment requires access to the home server** — this is a HITL
+issue.
+
+> Port `4001` is used to avoid conflicts with services already on the box
+> (3000 range, 8080, 8088, 8096, 8888). Tailscale is already installed and
+> configured, so no extra network setup is needed — anything reachable on the
+> server's LAN IP or Tailscale IP on port 4001 is reachable remotely.
+
+## Architecture (why one process)
+
+- **One PM2 process** (`kalima`) runs the compiled Express server
+  (`packages/server/dist/index.js`).
+- The server serves the **tRPC API** at `/trpc`, the **built frontend** as
+  static files from `packages/web/dist`, and an **SPA fallback** that serves
+  `index.html` for any non-API route.
+- The database is a **single SQLite file** — no separate DB process.
+
+## Prerequisites (one-time, on the home server)
+
+```bash
+# Node.js (v20+) — use nvm or nodesource
+# pnpm
+npm install -g pnpm
+
+# PM2
+npm install -g pm2
+
+# Log rotation module (only once, ever)
+pm2 install pm2-logrotate
+```
+
+### Auto-start on boot
+
+```bash
+pm2 startup systemd
+```
+
+PM2 prints a command like `sudo env PATH=$PATH:... pm2 startup systemd -u <user> --hp <home>`.
+**Run that printed command with `sudo`.** This installs a systemd unit that
+resurrects the saved PM2 process list on boot. After your first successful
+`pm2 start` + `pm2 save` (below), the app comes back on reboot automatically.
+
+### Log rotation settings (recommended)
+
+```bash
+pm2 set pm2-logrotate:max_size 10M
+pm2 set pm2-logrotate:retain 7
+pm2 set pm2-logrotate:compress true
+```
+
+## First deployment
+
+### 1. Clone
+
+```bash
+git clone https://github.com/AgkTF/kalima.git
+cd kalima
+git checkout main   # or the branch/commit you intend to deploy
+```
+
+### 2. Create the production environment file
+
+`packages/server/.env` is **gitignored** (it holds secrets). Copy the example
+and fill it in:
+
+```bash
+cp packages/server/.env.example packages/server/.env
+$EDITOR packages/server/.env
+```
+
+Required values:
+
+| Var | Example | Notes |
+| --- | --- | --- |
+| `DATABASE_URL` | `file:./prisma/prod.db` | SQLite path (relative to `packages/server`). A fresh clone has **no** `*.db` files — `prisma migrate deploy` creates it empty. Do **not** copy `dev.db` from a dev machine. |
+| `LLM_API_KEY` | `...` | Your OpenAI-compatible API key. |
+| `LLM_BASE_URL` | `https://api.deepinfra.com/v1/openai` | |
+| `LLM_CHEAP_MODEL` | `Qwen/...` | |
+| `LLM_PREMIUM_MODEL` | `google/...` | |
+| `PORT` | _(leave out)_ | Enforced to `4001` by `ecosystem.config.js`. If you set it, use `4001`. |
+
+> `dotenv` does not override existing process env vars, so PM2's `PORT=4001`
+> from the ecosystem file always wins — safe even if `.env` still says `3001`.
+
+### 3. Deploy
+
+```bash
+./scripts/deploy.sh
+```
+
+This runs, in order:
+
+1. `pnpm install --frozen-lockfile`
+2. `prisma migrate deploy` — applies all migrations to the **fresh** DB and
+   generates the Prisma client into `src/generated/prisma/` (gitignored).
+3. `pnpm --filter server build` — `tsc` compiles `src/` → `dist/`.
+4. `pnpm --filter web build` — Vite builds `packages/web/dist/`.
+5. `pm2 start ecosystem.config.js` (or `pm2 restart kalima` if already running)
+6. `pm2 save` — persists the process list so it resurrects on reboot.
+
+The script refuses to start if `packages/server/.env` is missing, and restarts
+the existing process instead of creating a duplicate on re-runs.
+
+> **Fresh database guarantee:** the deploy never carries dev data. The only DB
+> that exists on the server is the one `prisma migrate deploy` creates from
+> migrations — empty on first deploy.
+
+### 4. Verify
+
+```bash
+# Locally on the server
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' http://localhost:4001/
+
+# From another machine on the LAN (replace with the server's LAN IP)
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' http://<server-lan-ip>:4001/
+
+# Over Tailscale (replace with the server's Tailscale IP)
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' http://<server-tailscale-ip>:4001/
+
+pm2 status
+pm2 logs kalima --lines 20
+```
+
+All three should return `HTTP 200`. The SPA fallback serves `index.html` for
+any non-`/trpc` path, so unknown routes also return `200` (the React app handles
+client-side routing).
+
+> If the LAN/Tailscale URL fails but `localhost:4001` works, check the firewall:
+> `sudo ufw allow 4001/tcp` (or whatever firewall you use).
+
+## Updating the app (re-deploy)
+
+```bash
+cd kalima
+git pull
+./scripts/deploy.sh      # reinstall -> migrate -> rebuild -> pm2 restart kalima -> save
+```
+
+`pm2 restart kalima` picks up the freshly built `dist/` with near-zero downtime.
+
+## Day-to-day PM2 commands
+
+```bash
+pm2 status                 # process table
+pm2 logs kalima            # live logs (Ctrl-C to detach)
+pm2 logs kalima --lines 50 # last 50 lines
+pm2 restart kalima         # manual restart
+pm2 stop kalima            # stop (process stays in the list)
+pm2 delete kalima          # remove from the list entirely
+pm2 monit                  # live CPU/memory terminal UI
+```
+
+## Troubleshooting
+
+- **`prisma migrate deploy` fails / client missing:** ensure you ran it from
+  `packages/server` (the script does this for you). It both applies migrations
+  and generates the Prisma client the `tsc` build depends on.
+- **`dist/index.js` not found:** the build step must run after migrate deploy
+  (which generates the Prisma client). The deploy script enforces this order.
+- **Frontend 404s after deploy:** confirm `packages/web/dist/index.html` exists
+  (`pnpm --filter web build`). The server looks for it at
+  `../../web/dist` relative to `packages/server/dist`.
+- **Process not coming back after reboot:** you forgot `pm2 save`, or the
+  `pm2 startup systemd` generated command wasn't run with `sudo`.
+- **Using dev data by accident:** the script warns if `DATABASE_URL` still
+  points at `dev.db`. Use a dedicated `prod.db` path in production `.env`.
+
+## Files this issue adds
+
+| File | Purpose |
+| --- | --- |
+| `ecosystem.config.js` | PM2 process declaration (name `kalima`, cwd `packages/server`, script `dist/index.js`, `PORT=4001`) |
+| `scripts/deploy.sh` | Idempotent deploy script (install → migrate → build → pm2) |
+| `docs/deployment.md` | This runbook |

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,57 @@
+/**
+ * PM2 process configuration for Kalima.
+ *
+ * Start:          pm2 start ecosystem.config.js
+ * Restart:        pm2 restart kalima
+ * Stop:           pm2 stop kalima
+ * Logs:           pm2 logs kalima
+ * Save process list (survives reboot once `pm2 startup` is set up):
+ *                pm2 save
+ *
+ * Only ONE process is needed: the Express server serves the compiled tRPC API
+ * and the built frontend static files (with SPA fallback) from a single Node
+ * process. The database is a single SQLite file — no separate DB process.
+ *
+ * Environment:
+ *   PORT and NODE_ENV are set below (authoritative — dotenv does not override
+ *   existing process env vars, so these win over anything in .env).
+ *   Everything else (DATABASE_URL, LLM_API_KEY, LLM_BASE_URL, LLM_*_MODEL) is
+ *   read from packages/server/.env by dotenv at startup. See docs/deployment.md
+ *   for how to create that file on a fresh server.
+ *
+ * Full runbook: docs/deployment.md
+ */
+module.exports = {
+  apps: [
+    {
+      name: "kalima",
+      // Resolve relative to this file, i.e. <repo>/packages/server
+      cwd: "./packages/server",
+      // Compiled output of `pnpm --filter server build` (tsc: src/ -> dist/)
+      script: "dist/index.js",
+
+      // SQLite is a single file — fork mode, one instance. No clustering.
+      exec_mode: "fork",
+      instances: 1,
+
+      // Auto-restart on crash (pm2 default, made explicit).
+      autorestart: true,
+      max_restarts: 10,
+      min_uptime: "10s",
+      // Back off between restarts so a crash loop doesn't hammer the box.
+      exp_backoff_restart_delay: 200,
+
+      // Never restart on file changes in production.
+      watch: false,
+
+      env: {
+        NODE_ENV: "production",
+        PORT: 4001,
+      },
+
+      // Use pm2's default log location (~/.pm2/logs/) so pm2-logrotate manages
+      // rotation out of the box. Timestamp every line for easier triage.
+      time: true,
+    },
+  ],
+};

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scripts/deploy.sh — Kalima production deploy on an Ubuntu home server.
+#
+# Prereqs (one-time, see docs/deployment.md):
+#   - Node.js, pnpm, pm2 installed globally
+#   - pm2-logrotate installed:  pm2 install pm2-logrotate
+#   - pm2 startup configured:    pm2 startup systemd  (then run the printed command with sudo)
+#   - packages/server/.env created from .env.example with real LLM_API_KEY etc.
+#
+# This script is idempotent: safe to re-run for updates. It never carries over
+# dev data — the SQLite file only exists after `prisma migrate deploy` creates it
+# fresh on first deploy.
+#
+# Usage:
+#   scripts/deploy.sh             # full deploy (install -> migrate -> build -> start)
+#   scripts/deploy.sh --no-start  # everything except starting pm2 (useful before first pm2 setup)
+#
+# Run from the repository root, on the branch you intend to deploy (usually `main`).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+START_PM2=1
+if [[ "${1:-}" == "--no-start" ]]; then START_PM2=0; fi
+
+SERVER_DIR="$REPO_ROOT/packages/server"
+ENV_FILE="$SERVER_DIR/.env"
+ENV_EXAMPLE="$SERVER_DIR/.env.example"
+
+log() { printf '\n\033[1;34m▶ %s\033[0m\n' "$*"; }
+err() { printf '\n\033[1;31m✖ %s\033[0m\n' "$*" >&2; }
+
+# --- guards ------------------------------------------------------------------
+command -v pnpm >/dev/null || { err "pnpm not found. Install: npm i -g pnpm"; exit 1; }
+if [[ $START_PM2 -eq 1 ]]; then
+  command -v pm2 >/dev/null || { err "pm2 not found. Install: npm i -g pm2"; exit 1; }
+fi
+
+# A .env with real secrets must exist before we start the app. We do NOT
+# auto-generate secrets. On a fresh server, copy .env.example -> .env and fill it
+# in first (see docs/deployment.md).
+if [[ ! -f "$ENV_FILE" ]]; then
+  err "Missing $ENV_FILE"
+  echo "  Copy the example and fill in production values first:"
+  echo "    cp $ENV_EXAMPLE $ENV_FILE"
+  echo "  At minimum set DATABASE_URL, LLM_API_KEY, LLM_BASE_URL."
+  echo "  PORT is enforced to 4001 by ecosystem.config.js; you may leave it out of .env."
+  exit 1
+fi
+
+# Make sure DATABASE_URL points at a production database, not the dev one, to
+# avoid silently using dev data. We only warn (don't hard-fail) so a fresh clone
+# whose .env was copied from .env.example is still OK — the dev.db file does not
+# exist on a fresh clone, so migrate deploy creates it empty.
+if grep -q '^DATABASE_URL=file:./prisma/dev.db' "$ENV_FILE"; then
+  echo "  ⚠  DATABASE_URL still points at prisma/dev.db."
+  echo "     That's fine for a fresh clone (the file is gitignored and won't exist),"
+  echo "     but consider a dedicated prod path, e.g. file:./prisma/prod.db"
+fi
+
+# --- 1. install dependencies -------------------------------------------------
+log "Installing dependencies (pnpm install)"
+pnpm install --frozen-lockfile
+
+# --- 2. apply migrations + generate Prisma client -----------------------------
+# `prisma migrate deploy` applies all pending migrations to the (fresh) SQLite
+# file and generates the Prisma client into src/generated/prisma (gitignored).
+# The generated client is required by the `tsc` build step that follows.
+log "Applying Prisma migrations (fresh DB on first deploy)"
+( cd "$SERVER_DIR" && pnpm exec prisma migrate deploy )
+
+# --- 3. build server (tsc: src/ -> dist/) -------------------------------------
+log "Building server (pnpm --filter server build)"
+pnpm --filter server build
+
+# --- 4. build frontend (vite -> packages/web/dist) ---------------------------
+log "Building frontend (pnpm --filter web build)"
+pnpm --filter web build
+
+# --- 5. start / restart with pm2 ---------------------------------------------
+if [[ $START_PM2 -eq 1 ]]; then
+  log "Starting with pm2 (ecosystem.config.js)"
+  if pm2 describe kalima >/dev/null 2>&1; then
+    # Already managed by pm2 — restart picks up the freshly built dist/.
+    pm2 restart kalima
+  else
+    pm2 start ecosystem.config.js
+  fi
+  pm2 save
+  echo
+  pm2 status
+  echo
+  echo "  ✅ Kalima should be up. Verify:"
+  echo "     curl -sS -o /dev/null -w 'HTTP %{http_code}\\n' http://localhost:4001/"
+else
+  log "Skipping pm2 start (--no-start). Start manually with: pm2 start ecosystem.config.js"
+fi


### PR DESCRIPTION
Closes #29.

## What

Production deployment configuration for running Kalima on an Ubuntu home server with PM2 — one process serving the tRPC API + built frontend (SPA fallback) backed by a single SQLite file.

## Changes

- **`ecosystem.config.js`** — PM2 process `kalima`: cwd `packages/server`, script `dist/index.js`, env `PORT=4001` / `NODE_ENV=production`, fork mode, auto-restart with backoff, default pm2 log location (pm2-logrotate ready).
- **`scripts/deploy.sh`** — idempotent deploy: `pnpm install` → `prisma migrate deploy` → build server → build web → `pm2 start`/`restart` → `pm2 save`. Refuses to start without `packages/server/.env`; never carries dev data.
- **`docs/deployment.md`** — runbook: `pm2 install pm2-logrotate`, `pm2 startup systemd`, `.env` setup, first deploy, re-deploy, LAN + Tailscale access, troubleshooting.
- **`README.md`** — production section now points at the runbook.

## Acceptance criteria

- [x] `ecosystem.config.js` at repo root: name `kalima`, cwd `packages/server`, script `dist/index.js`, env `PORT=4001`
- [x] Deploy script covering clone → `pnpm install` → `prisma migrate deploy` → `pnpm --filter server build` → `pnpm --filter web build` → `pm2 start`
- [x] Instructions for `pm2 save` + `pm2 startup systemd`
- [x] Instructions for `pm2 install pm2-logrotate`
- [x] App reachable on `http://<ip>:4001` (LAN) and `http://<tailscale-ip>:4001` (documented + verified locally)
- [x] Fresh DB on first deploy — no dev data carried over

## Verification

- `prisma migrate deploy` against a fresh throwaway DB applies all 3 migrations **and** auto-generates the Prisma client into the gitignored `src/generated/prisma/` (required by the `tsc` build, which is why build comes after migrate).
- `./scripts/deploy.sh --no-start` runs the full pipeline (install → migrate → build server → build web) to exit 0.
- Started compiled `node packages/server/dist/index.js` on port 4001 against the fresh DB: `/` → 200, `/trpc` → 404 (server responding correctly), SPA fallback `/some/spa/route` → 200 `text/html`.
- Missing-`.env` guard fails with a clear actionable message.

## HITL note

This issue is labeled `ready-for-human`: the config/docs are agent-prepared, but the actual deployment (installing pm2, running `pm2 startup systemd`, filling in `LLM_API_KEY` in `.env`, opening the firewall, verifying over Tailscale) requires access to the home server. See `docs/deployment.md` for the step-by-step.

Blocked-by #28 (merged in #40).