### PR TITLE
fix(deploy): pnpm 11 build allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,5 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "typescript": "^5.8.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "@prisma/engines",
-      "prisma",
-      "better-sqlite3"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,19 @@
 packages:
   - "packages/*"
+
+# Packages allowed to run native build scripts (postinstall/install).
+# Declared in BOTH forms for cross-version pnpm compatibility:
+#   - allowBuilds            -> pnpm >= 11  (replaces onlyBuiltDependencies)
+#   - onlyBuiltDependencies  -> pnpm 10.x   (still reads this form)
+# pnpm 11 no longer reads the `pnpm` field of package.json, so this MUST live
+# here — keeping it only in package.json breaks installs on pnpm 11.
+allowBuilds:
+  esbuild: true
+  "@prisma/engines": true
+  prisma: true
+  better-sqlite3: true
+onlyBuiltDependencies:
+  - esbuild
+  - "@prisma/engines"
+  - prisma
+  - better-sqlite3


### PR DESCRIPTION
Follow-up fix to #41 (issue #29). Discovered during the first real deploy on the home server.

## Problem

`./scripts/deploy.sh` fails on pnpm 11 with:

```
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: @prisma/engines@7.8.0, better-sqlite3@12.9.0, esbuild@0.25.12, esbuild@0.27.7, prisma@7.8.0
```

pnpm 11 made three changes that combined to break installs:

1. **No longer reads the `pnpm` field of `package.json`** — and our allowlist lived exactly there (`pnpm.onlyBuiltDependencies`).
2. **Removed `onlyBuiltDependencies`** in favor of an `allowBuilds` map (`{ name: true }`).
3. **`strictDepBuilds` now defaults to `true`** — unapproved builds abort instead of warning.

So on pnpm 11 the allowlist was silently ignored and every native build (esbuild, @prisma/engines, prisma, better-sqlite3) was blocked. It builds fine on pnpm 10.x (CI / dev), which is why #41 didn't catch it.

## Fix

Move the allowlist from `package.json#pnpm` into `pnpm-workspace.yaml`, declaring it in **both** forms so it works across pnpm versions:

```yaml
allowBuilds:              # pnpm >= 11
  esbuild: true
  "@prisma/engines": true
  prisma: true
  better-sqlite3: true
onlyBuiltDependencies:    # pnpm 10.x (CI / dev)
  - esbuild
  - "@prisma/engines"
  - prisma
  - better-sqlite3
```

Removed the now-dead `pnpm` field from `package.json`.

- pnpm 11 reads `allowBuilds`; `onlyBuiltDependencies` is harmlessly ignored.
- pnpm 10 reads `onlyBuiltDependencies`; `allowBuilds` is an unknown key and harmlessly ignored.

## Verification

- `pnpm install --frozen-lockfile` on pnpm 10.33.2: exit 0, no `Ignored build scripts`, native binaries present (`better_sqlite3.node`, `esbuild`).
- `./scripts/deploy.sh --no-start` (migrate → build server → build web): exit 0.
- `pnpm-lock.yaml` unchanged — `--frozen-lockfile` still holds (config-only change).