### PR TITLE
fix(deploy): run prisma generate before server build

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,12 +95,14 @@ Required values:
 This runs, in order:
 
 1. `pnpm install --frozen-lockfile`
-2. `prisma migrate deploy` — applies all migrations to the **fresh** DB and
-   generates the Prisma client into `src/generated/prisma/` (gitignored).
-3. `pnpm --filter server build` — `tsc` compiles `src/` → `dist/`.
-4. `pnpm --filter web build` — Vite builds `packages/web/dist/`.
-5. `pm2 start ecosystem.config.js` (or `pm2 restart kalima` if already running)
-6. `pm2 save` — persists the process list so it resurrects on reboot.
+2. `prisma migrate deploy` — applies all migrations to the **fresh** DB.
+3. `prisma generate` — generates the Prisma client into `src/generated/prisma/`
+   (gitignored). Required by the `tsc` build; `migrate deploy` does **not** do
+   this automatically, so on a fresh clone it must run explicitly.
+4. `pnpm --filter server build` — `tsc` compiles `src/` → `dist/`.
+5. `pnpm --filter web build` — Vite builds `packages/web/dist/`.
+6. `pm2 start ecosystem.config.js` (or `pm2 restart kalima` if already running)
+7. `pm2 save` — persists the process list so it resurrects on reboot.
 
 The script refuses to start if `packages/server/.env` is missing, and restarts
 the existing process instead of creating a duplicate on re-runs.
@@ -156,11 +158,14 @@ pm2 monit                  # live CPU/memory terminal UI
 
 ## Troubleshooting
 
-- **`prisma migrate deploy` fails / client missing:** ensure you ran it from
-  `packages/server` (the script does this for you). It both applies migrations
-  and generates the Prisma client the `tsc` build depends on.
-- **`dist/index.js` not found:** the build step must run after migrate deploy
-  (which generates the Prisma client). The deploy script enforces this order.
+- **`prisma migrate deploy` fails / client missing:** `migrate deploy` applies
+  migrations but does **not** generate the Prisma client. The deploy script runs
+  `prisma generate` right after; if you skip it, the `tsc` build fails on the
+  `./generated/prisma/client.js` import. The client dir is gitignored, so on a
+  fresh clone it only exists once `prisma generate` has run.
+- **`dist/index.js` not found:** the build step must run after `prisma generate`
+  (which creates the gitignored Prisma client) and `prisma migrate deploy`. The
+  deploy script enforces this order.
 - **Frontend 404s after deploy:** confirm `packages/web/dist/index.html` exists
   (`pnpm --filter web build`). The server looks for it at
   `../../web/dist` relative to `packages/server/dist`.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -63,22 +63,29 @@ fi
 log "Installing dependencies (pnpm install)"
 pnpm install --frozen-lockfile
 
-# --- 2. apply migrations + generate Prisma client -----------------------------
-# `prisma migrate deploy` applies all pending migrations to the (fresh) SQLite
-# file and generates the Prisma client into src/generated/prisma (gitignored).
-# The generated client is required by the `tsc` build step that follows.
+# --- 2. apply migrations to the (fresh) DB -----------------------------------
+# `prisma migrate deploy` applies all pending migrations to the SQLite file.
+# On a fresh clone the file does not exist (it is gitignored), so this creates
+# it empty — no dev data is carried over.
 log "Applying Prisma migrations (fresh DB on first deploy)"
 ( cd "$SERVER_DIR" && pnpm exec prisma migrate deploy )
 
-# --- 3. build server (tsc: src/ -> dist/) -------------------------------------
+# --- 3. generate Prisma client (required by the tsc build) -------------------
+# `migrate deploy` does NOT generate the client, and src/generated/prisma/ is
+# gitignored, so on a fresh clone it does not exist. Without this the server
+# `tsc` build fails on the `./generated/prisma/client.js` import.
+log "Generating Prisma client"
+( cd "$SERVER_DIR" && pnpm exec prisma generate )
+
+# --- 4. build server (tsc: src/ -> dist/) -------------------------------------
 log "Building server (pnpm --filter server build)"
 pnpm --filter server build
 
-# --- 4. build frontend (vite -> packages/web/dist) ---------------------------
+# --- 5. build frontend (vite -> packages/web/dist) ---------------------------
 log "Building frontend (pnpm --filter web build)"
 pnpm --filter web build
 
-# --- 5. start / restart with pm2 ---------------------------------------------
+# --- 6. start / restart with pm2 ---------------------------------------------
 if [[ $START_PM2 -eq 1 ]]; then
   log "Starting with pm2 (ecosystem.config.js)"
   if pm2 describe kalima >/dev/null 2>&1; then


### PR DESCRIPTION
Follow-up to #41 / #42 (issue #29). The deploy hit this on the first real run on the home server.

## Problem

`./scripts/deploy.sh` failed at the server build step on a fresh clone:

```
▶ Building server (pnpm --filter server build)
Found 15 errors in 10 files.
  src/prisma.ts:2
  src/router.ts:13
  src/services/app.ts:1
  ... (every file importing the Prisma client)
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] server@ build: `tsc`  Exit status 2
```

All 15 errors are `Cannot find module './generated/prisma/client.js'`.

## Root cause

The Prisma client lives in `src/generated/prisma/`, which is **gitignored**. It's only created by `prisma generate` — and **`prisma migrate deploy` does not generate it.** The deploy script ran `migrate deploy` then went straight to `tsc`, so on a fresh clone (no leftover generated client) the build broke on the missing import.

It passed earlier local verification only because the client was already present on the dev machine from prior runs — the project README itself runs `npx prisma generate` explicitly.

## Fix

Add `prisma generate` as an explicit step between migrate and build:

```
install → migrate deploy → prisma generate → build server → build web → pm2
```

- `scripts/deploy.sh`: new step 3 (`prisma generate`), renumbered subsequent steps.
- `docs/deployment.md`: documented the corrected order + updated troubleshooting note.

## Verification

Reproduced from a clean state (deleted `src/generated/` first), then ran `./scripts/deploy.sh --no-start`:

```
▶ Installing dependencies            Done
▶ Applying Prisma migrations         3 migrations applied
▶ Generating Prisma client           ✔ Generated Prisma Client (7.8.0)
▶ Building server                    tsc — clean
▶ Building frontend                  vite build — clean
exit 0
```

The actual deployment on the home server now succeeds end-to-end.