### PR TITLE
fix(server): load .env before prisma.ts reads DATABASE_URL

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,13 +1,15 @@
+// Load .env FIRST. This is a hoisted side-effect import, so it runs before any
+// other import below is evaluated — in particular before ./prisma.js reads
+// process.env.DATABASE_URL at module-load time. A plain dotenv.config() call
+// in the module body runs AFTER imports (ESM hoists imports), which is too late.
+import "dotenv/config";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as trpcExpress from "@trpc/server/adapters/express";
-import dotenv from "dotenv";
 import express from "express";
 import { fts, prisma } from "./prisma.js";
 import { appRouter } from "./router.js";
 import { LLMClient } from "./services/llm-client.js";
-
-dotenv.config();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = Number(process.env.PORT ?? 3001);


### PR DESCRIPTION
Issue #29 follow-up. All tRPC queries 500'd in production: "The table main.Entry does not exist in the current database." The app was connecting to an empty fallback DB instead of the one `prisma migrate deploy` populated.

## Root cause

ESM import ordering in `packages/server/src/index.ts`:

```ts
import dotenv from "dotenv";              // line 4
import { fts, prisma } from "./prisma.js"; // line 6 — evaluated FIRST (ESM hoists imports)
...
dotenv.config();                          // line 10 — runs AFTER all imports
```

`prisma.ts` reads `process.env.DATABASE_URL` at module-load time (line 5):

```ts
const databaseUrl = process.env.DATABASE_URL ?? "file:./prisma/dev.db";
```

ESM evaluates `./prisma.js` before the `dotenv.config()` call in `index.ts`'s body, so `process.env.DATABASE_URL` was undefined when `prisma.ts` ran -> it fell back to `file:./prisma/dev.db`.

Meanwhile `prisma migrate deploy` loads `.env` correctly (its `prisma.config.ts` does `import "dotenv/config"`), so it populated whatever `DATABASE_URL` `.env` points at (e.g. prod.db).

Net: migrations + schema went into prod.db; the app read an empty/nonexistent dev.db -> "table does not exist".

It was invisible in dev only because dev.db happens to have the schema from `prisma migrate dev`.

## Reproduction (confirmed)

With DATABASE_URL unset in the OS env (exactly how pm2 launches the process) and .env pointing at prod.db:

- Before fix: app created an empty dev.db (Entry count 0); prod.db had the schema (Entry count 1) -> 500 on every DB query.
- After fix: no dev.db created; app connected to prod.db; the startup PRAGMA journal_mode = WAL succeeded (it crashes on a missing/empty DB, so this proves the connection).

## Fix

Replace the late `import dotenv from "dotenv"; dotenv.config();` with a hoisted side-effect import as the first statement:

```ts
import "dotenv/config";   // runs before any other module, incl. ./prisma.js
import path from "node:path";
...
import { fts, prisma } from "./prisma.js";
```

This is the standard "load env first" idiom and matches what prisma.config.ts already does for the CLI.

## Verification

- Repro above (before=empty dev.db/500, after=prod.db/healthy).
- `pnpm --filter server test` -> 112 passed. No test imports prisma.ts (they construct their own PrismaClient with an explicit test.db URL), so this change doesn't affect them.
- typecheck + biome clean.

## Immediate server unblock (no rebuild needed)

The app falls back to file:./prisma/dev.db, so populate that file (the one the running app actually reads) and restart:

```bash
cd packages/server
DATABASE_URL="file:./prisma/dev.db" pnpm exec prisma migrate deploy
pm2 restart kalima
```

The proper fix is this PR: merge it, then `git pull && pnpm --filter server build && pm2 restart kalima` so the app honors DATABASE_URL from .env as intended.
