### PR TITLE
docs: clean up README setup & production sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,23 @@ A personal word bank that captures words and phrases from reading and watching, 
 ## Setup
 
 ```bash
+# Install dependencies
 pnpm install
-cd packages/server && npx prisma generate && npx prisma migrate dev
+
+# Create the server env file (gitignored) — fill in LLM_API_KEY for AI enrichment
+cp packages/server/.env.example packages/server/.env
+
+# Apply migrations, generate the Prisma client, and create the dev database
+pnpm --filter server exec prisma migrate dev
 ```
 
 ## Development
 
 ```bash
-pnpm dev          # starts both server (localhost:3001) and web (localhost:5173)
-pnpm lint          # check formatting and lint rules
-pnpm test          # run server tests
+pnpm dev        # starts server (localhost:3001) + web (localhost:5173)
+pnpm lint       # check formatting and lint rules
+pnpm typecheck  # typecheck all packages
+pnpm test       # run server tests
 ```
 
 ## Production
@@ -27,7 +34,7 @@ Tailscale access): **[docs/deployment.md](./docs/deployment.md)**.
 Quick start on an Ubuntu home server:
 
 ```bash
-./scripts/deploy.sh   # install -> prisma migrate deploy -> build server/web -> pm2 start
+./scripts/deploy.sh   # install -> migrate deploy -> generate -> build server/web -> pm2 start
 ```
 
 ## Project structure


### PR DESCRIPTION
Docs hygiene follow-up to the #29 deploy work. The README had drifted and had a real gap for fresh clones.

## Changes

**Setup** (the real gap):
- A fresh clone has **no `.env`** (gitignored), but both `prisma migrate dev` and the dev server need it. Added the `cp packages/server/.env.example packages/server/.env` step — without it, setup fails on a clean checkout.
- Dropped the redundant `prisma generate` (`migrate dev` auto-generates the client).
- `npx prisma` → `pnpm --filter server exec prisma` for pnpm consistency with the rest of the README.

**Development:**
- Aligned the inline comments; added `pnpm typecheck` (the script exists but wasn't listed).

**Production:**
- The `deploy.sh` comment was stale — it listed `install -> migrate deploy -> build -> pm2`, missing the `prisma generate` step added in #43. Updated to the actual order: `install -> migrate deploy -> generate -> build server/web -> pm2 start`.

## Verification

- Confirmed `pnpm --filter server exec prisma migrate dev` resolves the prisma CLI and reads `DATABASE_URL` from `.env` (via `prisma.config.ts`).
- typecheck + biome clean (pre-commit hooks passed).