### PR TITLE
docs: slash delimiter capture redesign

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,18 +25,25 @@ The enrichment step is perfectly suited for an LLM agent. The system should capt
 
 The user maintains reading/watching momentum by capturing **Items** fast during a **Session**, with enrichment happening afterward. They do NOT stop to enrich during reading.
 
-Capture input is a **text field** (typed or OS-level dictation) that feeds into an LLM parser on the server. The parser extracts the **Item**, any **Locator**, and any source hints from natural language input like:
+Capture input is a **single text field** (typed or OS-level dictation). There is no LLM parsing at capture time — the input is split locally using a **slash delimiter**. Everything before the first `/` is the **Item**; everything after is the optional **Locator** (in a session) or **Source Hint** (for a one-off). No slash means just the **Item** with no optional metadata.
 
-- "serendipity chapter 12 page 45"
-- "add serendipity, I'm on page forty five of chapter twelve"
-- "the phrase is call me Ishmael, page 1"
-- "serendipity — I heard it in a conversation"
+Examples:
+- `serendipity` → Item: "serendipity", no locator
+- `serendipity / p.45` → Item: "serendipity", Locator: "p.45"
+- `call me Ishmael / ch.1 p.1` → Item: "call me Ishmael", Locator: "ch.1 p.1"
+- `cardinal / conversation with a friend` → Item: "cardinal", Source Hint: "conversation with a friend" (one-off)
 
-No special audio pipeline needed — OS dictation produces text, the LLM parser handles the rest.
+As the user types the `/`, the input provides a **live visual split** — the Item renders in normal text, the Locator/Source Hint renders in accent color. This gives instant, deterministic parse verification with zero latency and no API call.
+
+The optional field is **context-dependent**: when a **Session** is active, the slash-delimited part maps to a **Locator**; for **One-offs**, it maps to a **Source Hint**. The same delimiter, one rule.
 
 **Decision: Use OS-level dictation into a text input, not Web Speech API.** Simpler, more reliable, works on every device, zero browser compatibility issues.
 
-The parsed result (Item + Locator) is displayed immediately in a running capture list, giving the user confirmation and parse verification without interrupting flow.
+**Decision: Slash delimiter, not LLM parsing.** Real-world usage revealed that the LLM parser was an expensive and unreliable detour. Users type just the word and hit capture; adding locators inline was rare and the LLM sometimes misinterpreted them. The slash delimiter is deterministic, instant, and requires no server call. See [ADR-0008](./docs/adr/0008-slash-delimiter-capture-parsing.md).
+
+**Capture list empty state**: When the optional field is empty, the capture list row shows a faded, tappable `+ add locator` (session) or `+ add source` (one-off) target instead of a placeholder dash. Tapping it enables **inline editing** — the target morphs into a text input on the same row. This turns the empty state into an invitation rather than a gap, and provides a retroactive entry path for optional metadata.
+
+Submit is instant — no loading state, no post-capture confirmation banner. The live visual split is the pre-submit verification; the item appearing in the list is the post-submit confirmation.
 
 ### 2. Session model: Explicit open/close, one Source per Session
 
@@ -44,7 +51,7 @@ A **Session** is opened with a **Source** (book title, show/episode, article URL
 
 Session metrics (duration, count of captures) are **nice-to-have** — trivially stored (open/close timestamps) but not a design driver. Add whenever.
 
-**One-offs** are captured without a **Session** — no **Source** association. A loose source hint (e.g., "conversation", "Twitter") is optional but not mandatory. Even a loose hint gives the agent a register signal that improves enrichment.
+**One-offs** are captured without a **Session** — no **Source** association. A loose **Source Hint** (e.g., "conversation with a friend", "in an ad while driving") is optional but not mandatory. The source hint is broader than a label — it captures the circumstance of encountering the word, which gives the enrichment agent a register and domain signal that improves enrichment quality for context-less one-offs.
 
 ### 3. Source Context: Optional, progressive, re-enrichable
 
@@ -61,7 +68,7 @@ For **books**: the user may paste chapter text when starting a session, or skip 
 
 ### 4. Enrichment pipeline: LLM-powered, with optional premium tier
 
-The enrichment agent receives: **Item** + **Locator** + **Source** metadata + **Source Context** (if available) + **existing Word Bank entries** (for connections).
+The enrichment agent receives: **Item** + **Locator** + **Source** metadata + **Source Context** (if available) + **Source Hint** (for one-offs) + **existing Word Bank entries** (for connections).
 
 It produces: **Definition**, **Translation** (Arabic), **Nuance** note, **Example** sentences, related **Entries**, and tags.
 
@@ -69,12 +76,7 @@ It produces: **Definition**, **Translation** (Arabic), **Nuance** note, **Exampl
 
 **Decision: No auto-approve based on LLM self-assessment.** The agent's self-assessed confidence was found to add friction rather than value — the user reviews every entry anyway, and the LLM's judgment doesn't reliably predict whether the user will agree. All enriched entries enter Review as `pending_review` with full expandable detail.
 
-**Capture parsing vs. enrichment — two distinct LLM calls per Capture:**
-
-1. **Parse** (at capture time, fast/cheap model) — extracts Item, Locator, source hints from raw input. Lightweight, near-real-time. Displayed immediately in the capture list for user verification.
-2. **Enrich** (after session close) — produces Definition, Translation, Nuance, Examples, Related Entries, Tags. Heavier, runs in background.
-
-The parse call is cheap and high-value: the user sees "serendipity · p.45" instead of the raw "serendipity chapter 12 page 45", enabling scan-verification at capture time.
+**One LLM call per Capture** — enrichment only. The capture parsing LLM call was removed in favor of the slash delimiter (see Design Decision #1). The enrichment prompt includes the **Source Hint** for one-offs, labeled as "Encounter context:" — this gives the agent situational context (register, domain) for words captured outside a session.
 
 **Enrichment trigger:** After a **Session** is closed, enrichment runs automatically for all pending **Captures**.
 
@@ -112,7 +114,7 @@ A badge on the Review tab shows the count of pending entries, so the user always
 | Frontend | React + Vite (PWA) + react-router v7 | Declarative routing with layout routes; single codebase for capture + review + browse; installable on mobile |
 | Database | SQLite + Prisma + FTS5 | Zero-ops deployment, Prisma for type-safe queries, FTS5 for full-text search |
 | Voice | OS-level dictation into text input | No audio pipeline needed — works everywhere, zero browser compatibility issues |
-| Capture parsing | LLM on server | Handles natural variations in how users describe items and locators |
+| Capture parsing | Slash delimiter (client-side split) | Deterministic, instant, no LLM call. Replaces the original LLM parser — see ADR-0008. |
 | Enrichment | LLM API calls | Fast/cheap model for all enrichment; premium tier available for future use |
 | Hosting | Linux home server | Personal tool, always accessible |
 
@@ -128,7 +130,7 @@ The enrichment pipeline, voice parsing, and re-enrichment logic live in a **serv
 ┌──────────────────────┐
 │ Transport (tRPC)      │  ← Thin wiring
 ├──────────────────────┤
-│ Service layer         │  ← enrichItem(), parseCapture(),
+│ Service layer         │  ← enrichItem(),
 │ (the brain)           │     reEnrich()
 ├──────────────────────┤
 │ External APIs         │  ← LLM calls
@@ -149,6 +151,7 @@ A fully enriched **Entry** contains:
 Item: "serendipity"
 Source: { title: "The Art of Innovation", type: "book", detail: "chapter 2" }
 Locator: "page 47"
+Source Hint: null (set for one-offs only — e.g., "conversation with a friend")
 Source Context: <surrounding sentence, if available>
 Language: English
 Register: Formal/Literary/etc.

--- a/design/DESIGN_SYSTEM.md
+++ b/design/DESIGN_SYSTEM.md
@@ -62,14 +62,10 @@ Inline feedback only — no toasts. Every server interaction provides feedback c
 ### Capture
 
 ```
-IDLE ───submit──▶ LOADING ───parse ok──▶ SUCCESS ───confirms──▶ IDLE
-               LOADING ───parse fail──▶ ERROR ────refills──▶ IDLE
+IDLE ───submit──▶ IDLE
 ```
 
-- **IDLE**: input ready, focused, placeholder visible
-- **LOADING**: button shows "…", input disabled
-- **SUCCESS**: parsed result confirmed inline below input, animates into list; input clears
-- **ERROR**: input refills with original text, inline error shown below: "Couldn't parse. Try again?"
+- **IDLE**: input ready, focused, placeholder visible. User types the item, optionally adds a `/` followed by a locator or source hint. Live visual split shows the parse in real time. On submit, the item appears instantly in the list and the input clears. No loading state (no LLM call), no confirmation banner (the list update is the confirmation). If a server error occurs (network, DB), the input refills with the original text and an inline error is shown: "Couldn't save. Try again?"
 
 ### Review: approve
 
@@ -150,7 +146,7 @@ ENRICHING ───some fail───▶ PARTIAL_FAIL ───open Review──
 - Source context is attached progressively via a separate "Add context" bottom sheet (text paste / URL paste / file upload). Supports .srt, .md, .pdf, and .txt files. Attaching context to an active session triggers re-enrichment of existing captures.
 - Closing a session triggers automatic enrichment
 - Running capture list scrolls above the session bar
-- Input clears on submit for rapid-fire capture; parsed result confirmed inline below input before animating into the list
+- Input clears on submit for rapid-fire capture; live visual split on the `/` delimiter provides pre-submit verification. No post-capture confirmation banner — the item appearing in the list is the confirmation. Capture list empty state shows tappable `+ add locator` / `+ add source` targets for optional metadata, with inline editing on tap.
 - Enrichment prompt template accessible from a "Prompt" button in the session bar. Opens a dedicated sheet.
   - No session active: edits the global default prompt
   - Session active: edits that session's override, pre-filled with the global default

--- a/docs/UBIQUITOUS_LANGUAGE.md
+++ b/docs/UBIQUITOUS_LANGUAGE.md
@@ -18,6 +18,7 @@
 | **Source Context** | Optional text from the **Source** (chapter, subtitle file, article) that enables higher-quality **Enrichment** | Source material, source text, reference text |
 | **Locator** | A position within a **Source** — page number, chapter, timestamp, or URL fragment — provided at capture time | Position, reference, pointer |
 | **One-off** | A **Capture** made outside of any **Session**, with no **Source** association | Standalone, ad-hoc |
+| **Source Hint** | Optional situational context for a **One-off** **Capture** — describes where and how the word was encountered (e.g., "conversation with a friend", "in an ad while driving"). Broader than a label: it captures the *circumstance of encounter*, giving the **Enrichment** agent a register and domain signal. Fed to the enrichment prompt under the label "Encounter context:". Distinct from **Source Context** (text from the source material) and **Enrichment Context** (prompt-level guidance). | Encounter context, source note |
 | **Enrichment Context** | Optional guidance text appended to the enrichment system prompt, scoped to a **Source** (e.g., "Focus on technical terminology and political concepts. Formal register."). Persists across **Sessions** of the same **Source**. Distinct from **Source Context** — this is *how* the agent should behave, not *what* it reads. | Source context (ambiguous), prompt context, enrichment hint
 
 ## Enrichment quality
@@ -52,7 +53,8 @@
 - A **Source** can have many **Sessions**
 - A **Session** has many **Captures**
 - A **Capture** belongs to exactly one **Session** or is a **One-off**
-- A **Capture** may include a **Locator** (chapter, page, timestamp)
+- A **Capture** may include a **Locator** (chapter, page, timestamp) — provided via the slash delimiter at capture time, or added retroactively via the tap target on the capture list
+- A **Capture** may include a **Source Hint** (for **One-offs** only) — provided via the slash delimiter at capture time, or added retroactively. Fed to the **Enrichment** prompt as "Encounter context:"
 - A **Source** may optionally have **Source Context** attached (chapter text, subtitle file, fetched article)
 - A **Source** may optionally have **Enrichment Context** — guidance text that tailors how the **Enrichment** agent behaves for that **Source** (e.g., "Focus on technical terminology")
 - **Enrichment Context** persists across **Sessions** of the same **Source**; editing it mid-session updates the **Source** and applies to future enrichments (current session and future sessions) without retroactively re-running completed ones
@@ -75,7 +77,7 @@
 
 > **Dev:** "What about words captured without any **Session** — like from a conversation?"
 
-> **Domain expert:** "That's a **One-off**. No **Source**, no **Locator**, minimal context. The **Enrichment** still runs, but with less precision. The user can optionally tag it with a loose source hint like 'conversation' to give the agent a register signal."
+> **Domain expert:** "That's a **One-off**. No **Source**, no **Locator**, minimal context. The **Enrichment** still runs, but with less precision. The user can optionally provide a **Source Hint** like 'conversation with a friend' or 'in an ad while driving' — this is fed to the enrichment agent as encounter context, giving it a register and domain signal that improves quality for context-less one-offs."
 
 ## Flagged ambiguities
 

--- a/docs/adr/0008-slash-delimiter-capture-parsing.md
+++ b/docs/adr/0008-slash-delimiter-capture-parsing.md
@@ -1,0 +1,18 @@
+# Slash delimiter replaces LLM capture parser
+
+Real-world usage revealed that the LLM capture parser was an expensive and unreliable detour. Users type just the word and hit capture — they rarely add locators inline, and when they do, the LLM sometimes misinterprets them (requiring a quotes workaround). We replaced the LLM parse call with a deterministic slash delimiter: everything before the first `/` is the Item, everything after is the optional Locator (in a session) or Source Hint (for a one-off). The split happens client-side with zero latency, a live visual split provides pre-submit verification, and the `rawText` field was dropped from the Capture model since the structured fields now contain all the information.
+
+## Considered Options
+
+- **LLM parser (original design)** — natural language input parsed by a server-side LLM call. Rejected: unreliable parsing, API latency on every capture, users had to wrap words in quotes as a workaround.
+- **Two structured fields** — separate input fields for item and locator. Rejected: adds visual weight to the input bar; the optional field is empty most of the time, making a persistent second field feel like a gap.
+- **Slash delimiter (chosen)** — single field, `/` as delimiter, client-side split, live visual feedback. Deterministic, instant, optional by nature (no slash = no locator).
+
+## Consequences
+
+- `CaptureParser` class and `capture-parser.ts` are deleted; the `capture-parser` tests and integration test are deleted.
+- `rawText` column is removed from the Capture table (Prisma migration required).
+- The tRPC `capture.create` mutation input changes from `{ rawText, sessionId? }` to `{ item, locator?, sourceHint?, sessionId? }`.
+- The capture feedback state machine simplifies from `IDLE → LOADING → SUCCESS/ERROR → IDLE` to `IDLE → IDLE` — no loading state, no confirmation banner.
+- The enrichment prompt is updated to include the Source Hint for one-offs, labeled as "Encounter context:".
+- The slash delimiter requires a live visual split in the input (overlay technique) to provide pre-submit parse verification — this was the LLM parser's job, now done client-side.


### PR DESCRIPTION
Updates project documentation to reflect the slash-delimiter capture redesign from the grilling session.

## Changes

- **CONTEXT.md**: Rewrote capture flow (design decision #1) and enrichment pipeline (design decision #4). Removed `rawText` from entry schema. Updated tech stack table and architecture diagram.
- **DESIGN_SYSTEM.md**: Simplified capture feedback state machine to `IDLE → IDLE`. Updated capture screen description.
- **UBIQUITOUS_LANGUAGE.md**: Added **Source Hint** as a formal term with broadened definition. Updated relationships and example dialogue.
- **ADR-0008**: New ADR recording the decision to replace LLM capture parsing with a slash delimiter.

## Context

Real-world usage of the deployed app revealed that the LLM capture parser was an expensive and unreliable detour. Users type just the word and hit capture — adding locators inline was rare, and the LLM sometimes misinterpreted them. This PR updates the docs to reflect the new design: a deterministic slash delimiter with client-side split, live visual split, context-dependent field mapping, tap target empty state, and instant submit.

Implementation issues: #46, #47, #48