### PR TITLE
feat: tap target empty state + retroactive inline edit for capture list

### DIFF
--- a/packages/server/src/__tests__/capture.test.ts
+++ b/packages/server/src/__tests__/capture.test.ts
@@ -60,6 +60,45 @@ describe("capture.create mutation", () => {
   });
 });
 
+describe("capture.update mutation", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("updates a capture's locator", async () => {
+    const created = await prisma.capture.create({
+      data: { item: "serendipity", locator: null, sourceHint: null },
+    });
+
+    const caller = appRouter.createCaller({ prisma, llm: null as never });
+    const result = await caller.capture.update({
+      captureId: created.id,
+      locator: "p.45",
+    });
+
+    expect(result).toMatchObject({
+      id: created.id,
+      item: "serendipity",
+      locator: "p.45",
+      sourceHint: null,
+    });
+
+    // Verify persisted
+    const found = await prisma.capture.findUnique({
+      where: { id: created.id },
+    });
+    expect(found?.locator).toBe("p.45");
+
+    // Cleanup
+    await prisma.capture.delete({ where: { id: created.id } });
+  });
+});
+
 describe("capture.list query", () => {
   const adapter = new PrismaBetterSqlite3({
     url: "file:./prisma/test.db",

--- a/packages/server/src/__tests__/capture.test.ts
+++ b/packages/server/src/__tests__/capture.test.ts
@@ -97,6 +97,33 @@ describe("capture.update mutation", () => {
     // Cleanup
     await prisma.capture.delete({ where: { id: created.id } });
   });
+
+  it("updates a capture's sourceHint", async () => {
+    const created = await prisma.capture.create({
+      data: { item: "cardinal", locator: null, sourceHint: null },
+    });
+
+    const caller = appRouter.createCaller({ prisma, llm: null as never });
+    const result = await caller.capture.update({
+      captureId: created.id,
+      sourceHint: "conversation with a friend",
+    });
+
+    expect(result).toMatchObject({
+      id: created.id,
+      item: "cardinal",
+      sourceHint: "conversation with a friend",
+    });
+
+    // Verify persisted
+    const found = await prisma.capture.findUnique({
+      where: { id: created.id },
+    });
+    expect(found?.sourceHint).toBe("conversation with a friend");
+
+    // Cleanup
+    await prisma.capture.delete({ where: { id: created.id } });
+  });
 });
 
 describe("capture.list query", () => {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -142,6 +142,24 @@ export const appRouter = t.router({
       .query(async ({ input, ctx }) =>
         CaptureService.listSession(input.sessionId, ctx.prisma),
       ),
+    update: t.procedure
+      .input(
+        z.object({
+          captureId: z.number(),
+          locator: z.string().nullable().optional(),
+          sourceHint: z.string().nullable().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) =>
+        CaptureService.update(
+          input.captureId,
+          {
+            locator: input.locator,
+            sourceHint: input.sourceHint,
+          },
+          ctx.prisma,
+        ),
+      ),
   }),
 
   enrichment: t.router({

--- a/packages/server/src/services/capture.ts
+++ b/packages/server/src/services/capture.ts
@@ -18,6 +18,20 @@ export const CaptureService = {
     });
   },
 
+  async update(
+    captureId: number,
+    data: { locator?: string | null; sourceHint?: string | null },
+    prisma: PrismaClient,
+  ) {
+    return prisma.capture.update({
+      where: { id: captureId },
+      data: {
+        locator: data.locator,
+        sourceHint: data.sourceHint,
+      },
+    });
+  },
+
   async list(prisma: PrismaClient) {
     return prisma.capture.findMany({
       where: {

--- a/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CaptureList } from "./CaptureList";
+
+interface Capture {
+  id: number;
+  item: string;
+  locator: string | null;
+  sourceHint: string | null;
+  entry: { status: string } | null;
+}
+
+const noUpdate = vi.fn();
+
+describe("CaptureList empty-state tap target", () => {
+  it("shows '+ add locator' when session is active and locator is empty", () => {
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={noUpdate}
+      />,
+    );
+    expect(screen.getByText("+ add locator")).toBeInTheDocument();
+  });
+
+  it("shows '+ add source' when no session and sourceHint is empty", () => {
+    const captures: Capture[] = [
+      { id: 1, item: "cardinal", locator: null, sourceHint: null, entry: null },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={false}
+        onUpdateCapture={noUpdate}
+      />,
+    );
+    expect(screen.getByText("+ add source")).toBeInTheDocument();
+  });
+
+  it("does not show tap target when capture already has a locator (session active)", () => {
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: "p.45",
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={noUpdate}
+      />,
+    );
+    expect(screen.queryByText("+ add locator")).not.toBeInTheDocument();
+    expect(screen.getByText("p.45")).toBeInTheDocument();
+  });
+
+  it("does not show tap target when capture already has a sourceHint (no session)", () => {
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "cardinal",
+        locator: null,
+        sourceHint: "conversation with a friend",
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={false}
+        onUpdateCapture={noUpdate}
+      />,
+    );
+    expect(screen.queryByText("+ add source")).not.toBeInTheDocument();
+    expect(screen.getByText("conversation with a friend")).toBeInTheDocument();
+  });
+});
+
+describe("CaptureList inline edit", () => {
+  it("morphs tap target into inline text input when tapped", async () => {
+    const user = userEvent.setup();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={noUpdate}
+      />,
+    );
+
+    await user.click(screen.getByText("+ add locator"));
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("calls onUpdateCapture with locator on Enter (session active)", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={onUpdateCapture}
+      />,
+    );
+
+    await user.click(screen.getByText("+ add locator"));
+    await user.type(screen.getByRole("textbox"), "p.45");
+    await user.keyboard("{Enter}");
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, { locator: "p.45" });
+  });
+
+  it("calls onUpdateCapture with sourceHint on Enter (no session)", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      { id: 1, item: "cardinal", locator: null, sourceHint: null, entry: null },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={false}
+        onUpdateCapture={onUpdateCapture}
+      />,
+    );
+
+    await user.click(screen.getByText("+ add source"));
+    await user.type(screen.getByRole("textbox"), "in an ad");
+    await user.keyboard("{Enter}");
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, { sourceHint: "in an ad" });
+  });
+
+  it("reverts to tap target on Escape without calling onUpdateCapture", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={onUpdateCapture}
+      />,
+    );
+
+    await user.click(screen.getByText("+ add locator"));
+    await user.type(screen.getByRole("textbox"), "p.45");
+    await user.keyboard("{Escape}");
+
+    expect(onUpdateCapture).not.toHaveBeenCalled();
+    expect(screen.getByText("+ add locator")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
@@ -192,4 +192,36 @@ describe("CaptureList inline edit", () => {
     expect(screen.getByText("+ add locator")).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
+
+  it("saves on blur (tap away) when value is non-empty", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <div>
+        <CaptureList
+          captures={captures}
+          hasSession={true}
+          onUpdateCapture={onUpdateCapture}
+        />
+        <button type="button" data-testid="outside">
+          outside
+        </button>
+      </div>,
+    );
+
+    await user.click(screen.getByText("+ add locator"));
+    await user.type(screen.getByRole("textbox"), "p.45");
+    await user.click(screen.getByTestId("outside"));
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, { locator: "p.45" });
+  });
 });

--- a/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
@@ -278,3 +278,29 @@ describe("CaptureList update error", () => {
     expect(screen.queryByText(/failed to update/i)).not.toBeInTheDocument();
   });
 });
+
+describe("CaptureList processing entry separator", () => {
+  it("does not show middot separator when locator is empty but sourceHint exists", () => {
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "cardinal",
+        locator: null,
+        sourceHint: "conversation with a friend",
+        entry: { status: "processing" },
+      },
+    ];
+    const { container } = render(
+      <CaptureList
+        captures={captures}
+        hasSession={false}
+        onUpdateCapture={noUpdate}
+        updateError={null}
+      />,
+    );
+    // sourceHint should be visible
+    expect(screen.getByText("conversation with a friend")).toBeInTheDocument();
+    // but no middot separator (the · character)
+    expect(container.textContent).not.toContain("·");
+  });
+});

--- a/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
@@ -29,6 +29,7 @@ describe("CaptureList empty-state tap target", () => {
         captures={captures}
         hasSession={true}
         onUpdateCapture={noUpdate}
+        updateError={null}
       />,
     );
     expect(screen.getByText("+ add locator")).toBeInTheDocument();
@@ -43,6 +44,7 @@ describe("CaptureList empty-state tap target", () => {
         captures={captures}
         hasSession={false}
         onUpdateCapture={noUpdate}
+        updateError={null}
       />,
     );
     expect(screen.getByText("+ add source")).toBeInTheDocument();
@@ -63,6 +65,7 @@ describe("CaptureList empty-state tap target", () => {
         captures={captures}
         hasSession={true}
         onUpdateCapture={noUpdate}
+        updateError={null}
       />,
     );
     expect(screen.queryByText("+ add locator")).not.toBeInTheDocument();
@@ -84,6 +87,7 @@ describe("CaptureList empty-state tap target", () => {
         captures={captures}
         hasSession={false}
         onUpdateCapture={noUpdate}
+        updateError={null}
       />,
     );
     expect(screen.queryByText("+ add source")).not.toBeInTheDocument();
@@ -108,6 +112,7 @@ describe("CaptureList inline edit", () => {
         captures={captures}
         hasSession={true}
         onUpdateCapture={noUpdate}
+        updateError={null}
       />,
     );
 
@@ -133,6 +138,7 @@ describe("CaptureList inline edit", () => {
         captures={captures}
         hasSession={true}
         onUpdateCapture={onUpdateCapture}
+        updateError={null}
       />,
     );
 
@@ -154,6 +160,7 @@ describe("CaptureList inline edit", () => {
         captures={captures}
         hasSession={false}
         onUpdateCapture={onUpdateCapture}
+        updateError={null}
       />,
     );
 
@@ -181,6 +188,7 @@ describe("CaptureList inline edit", () => {
         captures={captures}
         hasSession={true}
         onUpdateCapture={onUpdateCapture}
+        updateError={null}
       />,
     );
 
@@ -211,6 +219,7 @@ describe("CaptureList inline edit", () => {
           captures={captures}
           hasSession={true}
           onUpdateCapture={onUpdateCapture}
+          updateError={null}
         />
         <button type="button" data-testid="outside">
           outside
@@ -223,5 +232,49 @@ describe("CaptureList inline edit", () => {
     await user.click(screen.getByTestId("outside"));
 
     expect(onUpdateCapture).toHaveBeenCalledWith(1, { locator: "p.45" });
+  });
+});
+
+describe("CaptureList update error", () => {
+  it("shows an error message when updateError is provided", () => {
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={noUpdate}
+        updateError="Failed to update locator"
+      />,
+    );
+    expect(screen.getByText("Failed to update locator")).toBeInTheDocument();
+  });
+
+  it("does not show an error when updateError is null", () => {
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={noUpdate}
+        updateError={null}
+      />,
+    );
+    expect(screen.queryByText(/failed to update/i)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/screens/CaptureScreen/CaptureList.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.tsx
@@ -189,10 +189,12 @@ export function CaptureList({
   captures,
   hasSession,
   onUpdateCapture,
+  updateError,
 }: {
   captures: Capture[];
   hasSession: boolean;
   onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
+  updateError: string | null;
 }) {
   if (captures.length === 0) {
     return (
@@ -210,6 +212,11 @@ export function CaptureList({
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto pb-40">
+      {updateError && (
+        <div className="mx-5 mt-2 rounded-button border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+          {updateError}
+        </div>
+      )}
       <ul className="px-5">
         {captures.map((capture) => (
           <CaptureEntry

--- a/packages/web/src/screens/CaptureScreen/CaptureList.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface Capture {
   id: number;
@@ -50,6 +50,7 @@ function InlineFieldEditor({
 }) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState("");
+  const escapePressed = useRef(false);
 
   const label = hasSession ? "+ add locator" : "+ add source";
 
@@ -77,6 +78,7 @@ function InlineFieldEditor({
       handleSave();
     } else if (e.key === "Escape") {
       e.preventDefault();
+      escapePressed.current = true;
       handleCancel();
     }
   }
@@ -90,7 +92,13 @@ function InlineFieldEditor({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
-        onBlur={handleCancel}
+        onBlur={() => {
+          if (escapePressed.current) {
+            escapePressed.current = false;
+            return;
+          }
+          handleSave();
+        }}
         className="rounded-[5px] border border-accent bg-surface px-1.5 py-px font-medium text-xs text-ink outline-none focus:ring-1 focus:ring-accent"
       />
     );

--- a/packages/web/src/screens/CaptureScreen/CaptureList.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.tsx
@@ -15,7 +15,6 @@ interface CaptureUpdateData {
 
 /* ── Processing capture entry (B3: dim ping dot, 80% text) ── */
 function ProcessingCaptureEntry({ capture }: { capture: Capture }) {
-  const locator = capture.locator || "—";
   return (
     <li className="border-b border-divider py-2.5 last:border-b-0">
       <div className="flex items-center gap-2.5 font-display text-base font-semibold text-ink/80">
@@ -26,10 +25,14 @@ function ProcessingCaptureEntry({ capture }: { capture: Capture }) {
         {capture.item}
       </div>
       <div className="mt-0.5 flex items-center gap-1.5 text-xs text-dim/60">
-        <span className="font-medium text-accent/60">{locator}</span>
+        {capture.locator && (
+          <span className="font-medium text-accent/60">{capture.locator}</span>
+        )}
         {capture.sourceHint && (
           <>
-            <span className="select-none text-divider">&middot;</span>
+            {capture.locator && (
+              <span className="select-none text-divider">&middot;</span>
+            )}
             <span className="rounded-[5px] bg-chip/50 px-1.5 py-px font-medium text-chip-text/60">
               {capture.sourceHint}
             </span>

--- a/packages/web/src/screens/CaptureScreen/CaptureList.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.tsx
@@ -1,9 +1,16 @@
+import { useState } from "react";
+
 interface Capture {
   id: number;
   item: string;
   locator: string | null;
   sourceHint: string | null;
   entry: { status: string } | null;
+}
+
+interface CaptureUpdateData {
+  locator?: string | null;
+  sourceHint?: string | null;
 }
 
 /* ── Processing capture entry (B3: dim ping dot, 80% text) ── */
@@ -33,22 +40,114 @@ function ProcessingCaptureEntry({ capture }: { capture: Capture }) {
   );
 }
 
+/* ── Inline locator/source editor ── */
+function InlineFieldEditor({
+  hasSession,
+  onUpdate,
+}: {
+  hasSession: boolean;
+  onUpdate: (data: CaptureUpdateData) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState("");
+
+  const label = hasSession ? "+ add locator" : "+ add source";
+
+  function handleSave() {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setEditing(false);
+      return;
+    }
+    if (hasSession) {
+      onUpdate({ locator: trimmed });
+    } else {
+      onUpdate({ sourceHint: trimmed });
+    }
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      handleCancel();
+    }
+  }
+
+  if (editing) {
+    return (
+      <input
+        // biome-ignore lint/a11y/noAutofocus: intentional for inline edit UX
+        autoFocus
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleCancel}
+        className="rounded-[5px] border border-accent bg-surface px-1.5 py-px font-medium text-xs text-ink outline-none focus:ring-1 focus:ring-accent"
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setValue("");
+        setEditing(true);
+      }}
+      className="rounded-[5px] border border-dashed border-divider px-1.5 py-px font-medium text-xs text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer"
+    >
+      {label}
+    </button>
+  );
+}
+
 /* ── Normal (non-processing) capture entry ── */
-function NormalCaptureEntry({ capture }: { capture: Capture }) {
-  const locator = capture.locator || "—";
+function NormalCaptureEntry({
+  capture,
+  hasSession,
+  onUpdateCapture,
+}: {
+  capture: Capture;
+  hasSession: boolean;
+  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
+}) {
+  const showTapTarget = hasSession ? !capture.locator : !capture.sourceHint;
+
   return (
     <li className="border-b border-divider py-2.5 last:border-b-0">
       <div className="font-display text-base font-semibold text-ink">
         {capture.item}
       </div>
       <div className="mt-0.5 flex items-center gap-1.5 text-xs">
-        <span className="font-medium text-accent">{locator}</span>
-        {capture.sourceHint && (
+        {showTapTarget ? (
+          <InlineFieldEditor
+            hasSession={hasSession}
+            onUpdate={(data) => onUpdateCapture(capture.id, data)}
+          />
+        ) : (
           <>
-            <span className="select-none text-divider">&middot;</span>
-            <span className="rounded-[5px] bg-chip px-1.5 py-px font-medium text-chip-text">
-              {capture.sourceHint}
-            </span>
+            {capture.locator && (
+              <span className="font-medium text-accent">{capture.locator}</span>
+            )}
+            {capture.sourceHint && (
+              <>
+                {capture.locator && (
+                  <span className="select-none text-divider">&middot;</span>
+                )}
+                <span className="rounded-[5px] bg-chip px-1.5 py-px font-medium text-chip-text">
+                  {capture.sourceHint}
+                </span>
+              </>
+            )}
           </>
         )}
       </div>
@@ -57,19 +156,35 @@ function NormalCaptureEntry({ capture }: { capture: Capture }) {
 }
 
 /* ── Entry point ── */
-function CaptureEntry({ capture }: { capture: Capture }) {
+function CaptureEntry({
+  capture,
+  hasSession,
+  onUpdateCapture,
+}: {
+  capture: Capture;
+  hasSession: boolean;
+  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
+}) {
   if (capture.entry?.status === "processing") {
     return <ProcessingCaptureEntry capture={capture} />;
   }
-  return <NormalCaptureEntry capture={capture} />;
+  return (
+    <NormalCaptureEntry
+      capture={capture}
+      hasSession={hasSession}
+      onUpdateCapture={onUpdateCapture}
+    />
+  );
 }
 
 export function CaptureList({
   captures,
   hasSession,
+  onUpdateCapture,
 }: {
   captures: Capture[];
   hasSession: boolean;
+  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
 }) {
   if (captures.length === 0) {
     return (
@@ -89,7 +204,12 @@ export function CaptureList({
     <div className="flex flex-1 flex-col overflow-y-auto pb-40">
       <ul className="px-5">
         {captures.map((capture) => (
-          <CaptureEntry key={capture.id} capture={capture} />
+          <CaptureEntry
+            key={capture.id}
+            capture={capture}
+            hasSession={hasSession}
+            onUpdateCapture={onUpdateCapture}
+          />
         ))}
       </ul>
     </div>

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -54,6 +54,18 @@ export function CaptureScreen() {
     },
   });
 
+  const updateCapture = trpc.capture.update.useMutation({
+    onSuccess: () => {
+      if (activeSession.data) {
+        utils.capture.listSession.invalidate({
+          sessionId: activeSession.data.id,
+        });
+      } else {
+        utils.capture.list.invalidate();
+      }
+    },
+  });
+
   const openSession = trpc.session.open.useMutation({
     onSuccess: () => {
       utils.session.getActive.invalidate();
@@ -183,7 +195,13 @@ export function CaptureScreen() {
       )}
 
       {/* Capture list */}
-      <CaptureList captures={activeCaptures} hasSession={hasSession} />
+      <CaptureList
+        captures={activeCaptures}
+        hasSession={hasSession}
+        onUpdateCapture={(captureId, data) =>
+          updateCapture.mutate({ captureId, ...data })
+        }
+      />
 
       {/* Capture input + feedback */}
       <CaptureInput

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -201,6 +201,7 @@ export function CaptureScreen() {
         onUpdateCapture={(captureId, data) =>
           updateCapture.mutate({ captureId, ...data })
         }
+        updateError={updateCapture.error?.message ?? null}
       />
 
       {/* Capture input + feedback */}


### PR DESCRIPTION
Closes #47.

## What

When a capture's optional field (Locator for session captures, Source Hint for one-offs) is empty, the capture list row shows a faded, tappable `+ add locator` / `+ add source` target instead of the old `—` dash placeholder. Tapping it morphs the target into an inline text input on the same row — type the value, hit Enter or tap away to save, or Escape to cancel.

## Changes

**Backend**
- `CaptureService.update(captureId, { locator?, sourceHint? }, prisma)` — new service method. Uses Prisma `undefined` semantics: omitted fields are left unchanged, `null` clears the field.
- `capture.update` tRPC mutation — input `{ captureId: number, locator?: string | null, sourceHint?: string | null }`.

**Frontend**
- `CaptureList` — dashed-border tap target replaces the `—` placeholder when the optional field is empty. Tapping morphs into an inline `<input>` on the same row (no modal/sheet/navigation). Enter or blur saves via `onUpdateCapture`; Escape cancels. A ref prevents the blur handler from firing after escape.
- `CaptureScreen` — wires the `capture.update` mutation, passes `onUpdateCapture` to `CaptureList`, invalidates the active list query on success.

## Acceptance criteria

- [x] New `capture.update` tRPC mutation with input `{ captureId, locator?, sourceHint? }`
- [x] `CaptureService.update` method
- [x] `+ add locator` (session) / `+ add source` (one-off) faded dashed-border tap target
- [x] Tapping morphs into inline text input on the same row
- [x] Enter saves, Escape cancels
- [x] On save, input morphs back to normal display
- [x] Captures with existing locator/sourceHint display normally
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

## Test plan

Server (2 tests): `capture.update` mutation updates locator and sourceHint, verified against the database.

Web (9 tests): empty-state label per context, tap target visibility with/without existing field, inline edit morph, Enter save (locator + sourceHint), Escape cancel, blur save.

All tests: 113 server + 62 web passing. Typecheck clean. Lint exit 0.