### PR TITLE
Edit and delete individual Pending Captures

### DIFF
--- a/packages/server/src/__tests__/capture.test.ts
+++ b/packages/server/src/__tests__/capture.test.ts
@@ -2,6 +2,7 @@ import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { afterAll, describe, expect, it } from "vitest";
 import { PrismaClient } from "../generated/prisma/client.js";
 import { appRouter } from "../router.js";
+import { CaptureService } from "../services/capture.js";
 
 describe("capture.create mutation", () => {
   const adapter = new PrismaBetterSqlite3({
@@ -114,8 +115,19 @@ describe("capture.update mutation", () => {
   });
 
   it("updates a capture's locator", async () => {
+    const source = await prisma.source.create({
+      data: { name: "Router Update Locator", type: "book" },
+    });
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
     const created = await prisma.capture.create({
-      data: { item: "serendipity", locator: null, sourceHint: null },
+      data: {
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        sessionId: session.id,
+      },
     });
 
     const caller = appRouter.createCaller({ prisma, llm: null as never });
@@ -139,6 +151,8 @@ describe("capture.update mutation", () => {
 
     // Cleanup
     await prisma.capture.delete({ where: { id: created.id } });
+    await prisma.session.delete({ where: { id: session.id } });
+    await prisma.source.delete({ where: { id: source.id } });
   });
 
   it("updates a capture's sourceHint", async () => {
@@ -166,6 +180,216 @@ describe("capture.update mutation", () => {
 
     // Cleanup
     await prisma.capture.delete({ where: { id: created.id } });
+  });
+});
+
+describe("CaptureService pending state transitions", () => {
+  const adapter = new PrismaBetterSqlite3({
+    url: "file:./prisma/test.db",
+  });
+  const prisma = new PrismaClient({ adapter });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("updates a Pending Session Capture's Item and existing Locator", async () => {
+    const source = await prisma.source.create({
+      data: { name: "Pending Capture Edit", type: "book" },
+    });
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    const capture = await prisma.capture.create({
+      data: {
+        item: "serendipty",
+        locator: "p.44",
+        sessionId: session.id,
+      },
+    });
+
+    const updated = await CaptureService.update(
+      capture.id,
+      { item: "serendipity", locator: "p.45" },
+      prisma,
+    );
+
+    expect(updated).toMatchObject({
+      id: capture.id,
+      item: "serendipity",
+      locator: "p.45",
+    });
+
+    await prisma.capture.delete({ where: { id: capture.id } });
+    await prisma.session.delete({ where: { id: session.id } });
+    await prisma.source.delete({ where: { id: source.id } });
+  });
+
+  it("rejects a Locator change on a One-off without partially updating its Item", async () => {
+    const capture = await prisma.capture.create({
+      data: { item: "original", sourceHint: "in a conversation" },
+    });
+
+    await expect(
+      CaptureService.update(
+        capture.id,
+        { item: "changed", locator: "p.45" },
+        prisma,
+      ),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    const unchanged = await prisma.capture.findUniqueOrThrow({
+      where: { id: capture.id },
+    });
+    expect(unchanged).toMatchObject({
+      item: "original",
+      locator: null,
+      sourceHint: "in a conversation",
+    });
+
+    await prisma.capture.delete({ where: { id: capture.id } });
+  });
+
+  it("trims a Pending One-off's Item and existing Source Hint", async () => {
+    const capture = await prisma.capture.create({
+      data: { item: "cardnal", sourceHint: "in a conversation" },
+    });
+
+    const updated = await CaptureService.update(
+      capture.id,
+      { item: "  cardinal  ", sourceHint: "  in an ad  " },
+      prisma,
+    );
+
+    expect(updated).toMatchObject({
+      item: "cardinal",
+      sourceHint: "in an ad",
+    });
+
+    const cleared = await CaptureService.update(
+      capture.id,
+      { sourceHint: "   " },
+      prisma,
+    );
+    expect(cleared.sourceHint).toBeNull();
+
+    await expect(
+      CaptureService.update(capture.id, { item: "   " }, prisma),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      prisma.capture.findUniqueOrThrow({ where: { id: capture.id } }),
+    ).resolves.toMatchObject({ item: "cardinal", sourceHint: null });
+
+    await prisma.capture.delete({ where: { id: capture.id } });
+  });
+
+  it("rejects a Source Hint change on a Session Capture", async () => {
+    const source = await prisma.source.create({
+      data: { name: "Wrong Metadata Context", type: "book" },
+    });
+    const session = await prisma.session.create({
+      data: { sourceId: source.id },
+    });
+    const capture = await prisma.capture.create({
+      data: { item: "unchanged", locator: "p.12", sessionId: session.id },
+    });
+
+    await expect(
+      CaptureService.update(
+        capture.id,
+        { item: "changed", sourceHint: "not allowed" },
+        prisma,
+      ),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      prisma.capture.findUniqueOrThrow({ where: { id: capture.id } }),
+    ).resolves.toMatchObject({ item: "unchanged", locator: "p.12" });
+
+    await prisma.capture.delete({ where: { id: capture.id } });
+    await prisma.session.delete({ where: { id: session.id } });
+    await prisma.source.delete({ where: { id: source.id } });
+  });
+
+  it("rejects an update once Enrichment work exists", async () => {
+    const capture = await prisma.capture.create({
+      data: { item: "original", sourceHint: "in a conversation" },
+    });
+    await prisma.entry.create({
+      data: {
+        captureId: capture.id,
+        status: "processing",
+        definition: "",
+        translationArabic: "",
+        nuance: "",
+        examples: "[]",
+        tags: "[]",
+        relatedEntries: "[]",
+      },
+    });
+
+    await expect(
+      CaptureService.update(capture.id, { item: "changed" }, prisma),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    const unchanged = await prisma.capture.findUniqueOrThrow({
+      where: { id: capture.id },
+    });
+    expect(unchanged.item).toBe("original");
+
+    await prisma.entry.delete({ where: { captureId: capture.id } });
+    await prisma.capture.delete({ where: { id: capture.id } });
+  });
+
+  it("deletes a Pending Capture", async () => {
+    const capture = await prisma.capture.create({
+      data: { item: "accidental capture" },
+    });
+
+    await CaptureService.deletePending(capture.id, prisma);
+
+    await expect(
+      prisma.capture.findUnique({ where: { id: capture.id } }),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects deletion once Enrichment work exists without changing the Capture", async () => {
+    const capture = await prisma.capture.create({
+      data: { item: "already processing" },
+    });
+    await prisma.entry.create({
+      data: {
+        captureId: capture.id,
+        status: "processing",
+        definition: "",
+        translationArabic: "",
+        nuance: "",
+        examples: "[]",
+        tags: "[]",
+        relatedEntries: "[]",
+      },
+    });
+
+    await expect(
+      CaptureService.deletePending(capture.id, prisma),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    await expect(
+      prisma.capture.findUnique({ where: { id: capture.id } }),
+    ).resolves.toMatchObject({ id: capture.id, item: "already processing" });
+
+    await prisma.entry.delete({ where: { captureId: capture.id } });
+    await prisma.capture.delete({ where: { id: capture.id } });
+  });
+
+  it("rejects edits and deletion for a missing Capture", async () => {
+    const missingId = 2_147_483_647;
+
+    await expect(
+      CaptureService.update(missingId, { item: "missing" }, prisma),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    await expect(
+      CaptureService.deletePending(missingId, prisma),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -132,21 +132,36 @@ export const appRouter = t.router({
       ),
     update: t.procedure
       .input(
-        z.object({
-          captureId: z.number(),
-          locator: z.string().nullable().optional(),
-          sourceHint: z.string().nullable().optional(),
-        }),
+        z
+          .object({
+            captureId: z.number(),
+            item: z.string().trim().min(1).optional(),
+            locator: z.string().trim().nullable().optional(),
+            sourceHint: z.string().trim().nullable().optional(),
+          })
+          .refine(
+            ({ item, locator, sourceHint }) =>
+              item !== undefined ||
+              locator !== undefined ||
+              sourceHint !== undefined,
+            { message: "Provide at least one Capture field to update." },
+          ),
       )
       .mutation(async ({ input, ctx }) =>
         CaptureService.update(
           input.captureId,
           {
+            item: input.item,
             locator: input.locator,
             sourceHint: input.sourceHint,
           },
           ctx.prisma,
         ),
+      ),
+    delete: t.procedure
+      .input(z.object({ captureId: z.number() }))
+      .mutation(async ({ input, ctx }) =>
+        CaptureService.deletePending(input.captureId, ctx.prisma),
       ),
   }),
 

--- a/packages/server/src/services/capture.ts
+++ b/packages/server/src/services/capture.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import type { PrismaClient } from "../generated/prisma/client.js";
 
 export const CaptureService = {
@@ -20,16 +21,111 @@ export const CaptureService = {
 
   async update(
     captureId: number,
-    data: { locator?: string | null; sourceHint?: string | null },
+    data: {
+      item?: string;
+      locator?: string | null;
+      sourceHint?: string | null;
+    },
     prisma: PrismaClient,
   ) {
-    return prisma.capture.update({
-      where: { id: captureId },
-      data: {
-        locator: data.locator,
-        sourceHint: data.sourceHint,
+    const normalizedData = {
+      item: data.item?.trim(),
+      locator:
+        typeof data.locator === "string"
+          ? data.locator.trim() || null
+          : data.locator,
+      sourceHint:
+        typeof data.sourceHint === "string"
+          ? data.sourceHint.trim() || null
+          : data.sourceHint,
+    };
+
+    if (data.item !== undefined && !normalizedData.item) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "A Capture's Item cannot be empty.",
+      });
+    }
+
+    if (
+      normalizedData.locator !== undefined &&
+      normalizedData.sourceHint !== undefined
+    ) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "A Capture cannot accept both a Locator and a Source Hint.",
+      });
+    }
+
+    const result = await prisma.capture.updateMany({
+      where: {
+        id: captureId,
+        entry: null,
+        ...(normalizedData.locator !== undefined
+          ? { sessionId: { not: null } }
+          : normalizedData.sourceHint !== undefined
+            ? { sessionId: null }
+            : {}),
       },
+      data: normalizedData,
     });
+
+    if (result.count === 0) {
+      const capture = await prisma.capture.findUnique({
+        where: { id: captureId },
+        include: { entry: { select: { id: true } } },
+      });
+
+      if (!capture) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Capture ${captureId} not found.`,
+        });
+      }
+      if (capture.entry) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Only Pending Captures can be edited.",
+        });
+      }
+      if (normalizedData.locator !== undefined) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "One-off Captures do not accept a Locator.",
+        });
+      }
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Session Captures do not accept a Source Hint.",
+      });
+    }
+
+    return prisma.capture.findUniqueOrThrow({
+      where: { id: captureId },
+    });
+  },
+
+  async deletePending(captureId: number, prisma: PrismaClient): Promise<void> {
+    const result = await prisma.capture.deleteMany({
+      where: { id: captureId, entry: null },
+    });
+
+    if (result.count === 0) {
+      const capture = await prisma.capture.findUnique({
+        where: { id: captureId },
+        select: { id: true },
+      });
+      if (!capture) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Capture ${captureId} not found.`,
+        });
+      }
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: "Only Pending Captures can be deleted.",
+      });
+    }
   },
 
   async list(prisma: PrismaClient) {

--- a/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { CaptureList } from "./CaptureList";
@@ -96,6 +96,106 @@ describe("CaptureList empty-state tap target", () => {
 });
 
 describe("CaptureList inline edit", () => {
+  it("edits a Pending Capture's Item in place", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipty",
+        locator: "p.45",
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={onUpdateCapture}
+        updateError={null}
+      />,
+    );
+
+    await user.click(screen.getByText("serendipty"));
+    const input = screen.getByRole("textbox", {
+      name: "Item for serendipty",
+    });
+    await user.clear(input);
+    await user.type(input, "serendipity{Enter}");
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, {
+      item: "serendipity",
+    });
+  });
+
+  it("edits an existing Locator in place", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: "p.45",
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={true}
+        onUpdateCapture={onUpdateCapture}
+        updateError={null}
+      />,
+    );
+
+    await user.click(screen.getByText("p.45"));
+    const input = screen.getByRole("textbox", {
+      name: "Locator for serendipity",
+    });
+    expect(input).toHaveValue("p.45");
+    await user.clear(input);
+    await user.type(input, "p.46{Enter}");
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, { locator: "p.46" });
+  });
+
+  it("edits and clears an existing Source Hint in place", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "cardinal",
+        locator: null,
+        sourceHint: "in a conversation",
+        entry: null,
+      },
+    ];
+    render(
+      <CaptureList
+        captures={captures}
+        hasSession={false}
+        onUpdateCapture={onUpdateCapture}
+        updateError={null}
+      />,
+    );
+
+    await user.click(screen.getByText("in a conversation"));
+    const input = screen.getByRole("textbox", {
+      name: "Source Hint for cardinal",
+    });
+    expect(input).toHaveValue("in a conversation");
+    await user.clear(input);
+    await user.keyboard("{Enter}");
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, { sourceHint: null });
+    expect(
+      screen.queryByRole("button", { name: /Locator for cardinal/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("morphs tap target into inline text input when tapped", async () => {
     const user = userEvent.setup();
     const captures: Capture[] = [
@@ -201,6 +301,39 @@ describe("CaptureList inline edit", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
+  it("saves on blur after cancelling an earlier edit with Escape", async () => {
+    const user = userEvent.setup();
+    const onUpdateCapture = vi.fn();
+    const captures: Capture[] = [
+      {
+        id: 1,
+        item: "serendipity",
+        locator: null,
+        sourceHint: null,
+        entry: null,
+      },
+    ];
+    render(
+      <div>
+        <CaptureList
+          captures={captures}
+          hasSession={true}
+          onUpdateCapture={onUpdateCapture}
+          updateError={null}
+        />
+        <button type="button">outside</button>
+      </div>,
+    );
+
+    await user.click(screen.getByText("+ add locator"));
+    await user.type(screen.getByRole("textbox"), "cancelled{Escape}");
+    await user.click(screen.getByText("+ add locator"));
+    await user.type(screen.getByRole("textbox"), "p.45");
+    await user.click(screen.getByRole("button", { name: "outside" }));
+
+    expect(onUpdateCapture).toHaveBeenCalledWith(1, { locator: "p.45" });
+  });
+
   it("saves on blur (tap away) when value is non-empty", async () => {
     const user = userEvent.setup();
     const onUpdateCapture = vi.fn();
@@ -254,7 +387,9 @@ describe("CaptureList update error", () => {
         updateError="Failed to update locator"
       />,
     );
-    expect(screen.getByText("Failed to update locator")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Failed to update locator",
+    );
   });
 
   it("does not show an error when updateError is null", () => {
@@ -276,6 +411,224 @@ describe("CaptureList update error", () => {
       />,
     );
     expect(screen.queryByText(/failed to update/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("CaptureList Pending Capture deletion", () => {
+  const pendingCapture: Capture = {
+    id: 1,
+    item: "serendipity",
+    locator: null,
+    sourceHint: null,
+    entry: null,
+  };
+
+  function renderDeletion({
+    captures = [pendingCapture],
+    onDeleteCapture = vi.fn().mockResolvedValue(undefined),
+    onPendingDeletionChange,
+    onEnrich,
+    updateError = null,
+  }: {
+    captures?: Capture[];
+    onDeleteCapture?: (captureId: number) => Promise<void>;
+    onPendingDeletionChange?: (captureId: number | null) => void;
+    onEnrich?: () => void;
+    updateError?: string | null;
+  } = {}) {
+    return render(
+      <CaptureList
+        captures={captures}
+        hasSession={false}
+        onUpdateCapture={noUpdate}
+        updateError={updateError}
+        onDeleteCapture={onDeleteCapture}
+        onPendingDeletionChange={onPendingDeletionChange}
+        onEnrich={onEnrich}
+      />,
+    );
+  }
+
+  function confirmDelete(item = "serendipity") {
+    fireEvent.click(screen.getByRole("button", { name: `Delete ${item}` }));
+    fireEvent.click(
+      screen.getByRole("button", { name: `Confirm delete ${item}` }),
+    );
+  }
+
+  it("removes a confirmed deletion immediately and restores it on Undo", async () => {
+    const user = userEvent.setup();
+    const onDeleteCapture = vi.fn().mockResolvedValue(undefined);
+    const onPendingDeletionChange = vi.fn();
+    renderDeletion({ onDeleteCapture, onPendingDeletionChange });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete serendipity" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Confirm delete serendipity" }),
+    );
+
+    expect(screen.queryByText("serendipity")).not.toBeInTheDocument();
+    expect(onPendingDeletionChange).toHaveBeenLastCalledWith(1);
+    await user.click(
+      screen.getByRole("button", { name: "Undo delete serendipity" }),
+    );
+
+    expect(screen.getByText("serendipity")).toBeInTheDocument();
+    expect(onDeleteCapture).not.toHaveBeenCalled();
+    expect(onPendingDeletionChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("keeps focus and announces confirmation, deletion, and Undo", async () => {
+    const user = userEvent.setup();
+    renderDeletion();
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete serendipity" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Confirm delete serendipity" }),
+    ).toHaveFocus();
+
+    await user.click(
+      screen.getByRole("button", { name: "Cancel delete serendipity" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Delete serendipity" }),
+    ).toHaveFocus();
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete serendipity" }),
+    );
+    await user.keyboard("{Enter}");
+    expect(
+      screen.getByRole("button", { name: "Undo delete serendipity" }),
+    ).toHaveFocus();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "serendipity removed. Undo available for five seconds.",
+    );
+
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "serendipity restored.",
+    );
+  });
+
+  it("commits the deletion when the Undo window expires", async () => {
+    vi.useFakeTimers();
+    const onDeleteCapture = vi.fn().mockResolvedValue(undefined);
+
+    try {
+      renderDeletion({ onDeleteCapture });
+      confirmDelete();
+      expect(onDeleteCapture).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(onDeleteCapture).toHaveBeenCalledWith(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the Undo window while deletion is in flight", async () => {
+    vi.useFakeTimers();
+    let finishDelete: (() => void) | undefined;
+    const onDeleteCapture = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDelete = resolve;
+        }),
+    );
+
+    try {
+      renderDeletion({ onDeleteCapture });
+      confirmDelete();
+
+      act(() => vi.advanceTimersByTime(5_000));
+
+      expect(onDeleteCapture).toHaveBeenCalledWith(1);
+      expect(
+        screen.queryByRole("button", { name: "Undo delete serendipity" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Deleting capture…")).toBeInTheDocument();
+
+      await act(async () => finishDelete?.());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restores the Capture when deletion fails", async () => {
+    vi.useFakeTimers();
+
+    try {
+      renderDeletion({
+        updateError: "Delete failed",
+        onDeleteCapture: vi.fn().mockRejectedValue(new Error("failed")),
+      });
+      confirmDelete();
+
+      await act(async () => vi.advanceTimersByTimeAsync(5_000));
+
+      expect(screen.getByText("serendipity")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "serendipity could not be deleted and was restored.",
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent("Delete failed");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("blocks Enrichment while deletion is pending", () => {
+    vi.useFakeTimers();
+    const captures: Capture[] = [
+      { id: 1, item: "first", locator: null, sourceHint: null, entry: null },
+      { id: 2, item: "second", locator: null, sourceHint: null, entry: null },
+    ];
+
+    try {
+      renderDeletion({ captures, onEnrich: vi.fn() });
+      confirmDelete("first");
+
+      expect(
+        screen.getByRole("button", { name: "Enrich all (1)" }),
+      ).toBeDisabled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("commits a confirmed deletion when the Capture list unmounts", () => {
+    vi.useFakeTimers();
+    const onDeleteCapture = vi.fn().mockResolvedValue(undefined);
+
+    try {
+      const { unmount } = renderDeletion({ onDeleteCapture });
+      confirmDelete();
+
+      unmount();
+
+      expect(onDeleteCapture).toHaveBeenCalledWith(1);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not offer edit or delete controls after Enrichment begins", () => {
+    renderDeletion({
+      captures: [{ ...pendingCapture, entry: { status: "pending_review" } }],
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /Edit|Delete/ }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { CaptureList } from "./CaptureList";
+import { CaptureList } from "./components/CaptureList";
 
 interface Capture {
   id: number;

--- a/packages/web/src/screens/CaptureScreen/CaptureList.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureList.tsx
@@ -1,191 +1,12 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { Capture, CaptureUpdateData } from "./captureTypes";
+import { CaptureEntry } from "./components/CaptureEntry";
 
-interface Capture {
-  id: number;
-  item: string;
-  locator: string | null;
-  sourceHint: string | null;
-  entry: { status: string } | null;
-}
+const DELETE_UNDO_MS = 5_000;
 
-interface CaptureUpdateData {
-  locator?: string | null;
-  sourceHint?: string | null;
-}
-
-/* ── Processing capture entry (B3: dim ping dot, 80% text) ── */
-function ProcessingCaptureEntry({ capture }: { capture: Capture }) {
-  return (
-    <li className="border-b border-divider py-2.5 last:border-b-0">
-      <div className="flex items-center gap-2.5 font-display text-base font-semibold text-ink/80">
-        <span className="relative flex h-2 w-2 shrink-0">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-dim opacity-75" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-dim" />
-        </span>
-        {capture.item}
-      </div>
-      <div className="mt-0.5 flex items-center gap-1.5 text-xs text-dim/60">
-        {capture.locator && (
-          <span className="font-medium text-accent/60">{capture.locator}</span>
-        )}
-        {capture.sourceHint && (
-          <>
-            {capture.locator && (
-              <span className="select-none text-divider">&middot;</span>
-            )}
-            <span className="rounded-[5px] bg-chip/50 px-1.5 py-px font-medium text-chip-text/60">
-              {capture.sourceHint}
-            </span>
-          </>
-        )}
-      </div>
-    </li>
-  );
-}
-
-/* ── Inline locator/source editor ── */
-function InlineFieldEditor({
-  hasSession,
-  onUpdate,
-}: {
-  hasSession: boolean;
-  onUpdate: (data: CaptureUpdateData) => void;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState("");
-  const escapePressed = useRef(false);
-
-  const label = hasSession ? "+ add locator" : "+ add source";
-
-  function handleSave() {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      setEditing(false);
-      return;
-    }
-    if (hasSession) {
-      onUpdate({ locator: trimmed });
-    } else {
-      onUpdate({ sourceHint: trimmed });
-    }
-    setEditing(false);
-  }
-
-  function handleCancel() {
-    setEditing(false);
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleSave();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      escapePressed.current = true;
-      handleCancel();
-    }
-  }
-
-  if (editing) {
-    return (
-      <input
-        // biome-ignore lint/a11y/noAutofocus: intentional for inline edit UX
-        autoFocus
-        type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onBlur={() => {
-          if (escapePressed.current) {
-            escapePressed.current = false;
-            return;
-          }
-          handleSave();
-        }}
-        className="rounded-[5px] border border-accent bg-surface px-1.5 py-px font-medium text-xs text-ink outline-none focus:ring-1 focus:ring-accent"
-      />
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        setValue("");
-        setEditing(true);
-      }}
-      className="rounded-[5px] border border-dashed border-divider px-1.5 py-px font-medium text-xs text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer"
-    >
-      {label}
-    </button>
-  );
-}
-
-/* ── Normal (non-processing) capture entry ── */
-function NormalCaptureEntry({
-  capture,
-  hasSession,
-  onUpdateCapture,
-}: {
+interface PendingDeletion {
   capture: Capture;
-  hasSession: boolean;
-  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
-}) {
-  const showTapTarget = hasSession ? !capture.locator : !capture.sourceHint;
-
-  return (
-    <li className="border-b border-divider py-2.5 last:border-b-0">
-      <div className="font-display text-base font-semibold text-ink">
-        {capture.item}
-      </div>
-      <div className="mt-0.5 flex items-center gap-1.5 text-xs">
-        {showTapTarget ? (
-          <InlineFieldEditor
-            hasSession={hasSession}
-            onUpdate={(data) => onUpdateCapture(capture.id, data)}
-          />
-        ) : (
-          <>
-            {capture.locator && (
-              <span className="font-medium text-accent">{capture.locator}</span>
-            )}
-            {capture.sourceHint && (
-              <>
-                {capture.locator && (
-                  <span className="select-none text-divider">&middot;</span>
-                )}
-                <span className="rounded-[5px] bg-chip px-1.5 py-px font-medium text-chip-text">
-                  {capture.sourceHint}
-                </span>
-              </>
-            )}
-          </>
-        )}
-      </div>
-    </li>
-  );
-}
-
-/* ── Entry point ── */
-function CaptureEntry({
-  capture,
-  hasSession,
-  onUpdateCapture,
-}: {
-  capture: Capture;
-  hasSession: boolean;
-  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
-}) {
-  if (capture.entry?.status === "processing") {
-    return <ProcessingCaptureEntry capture={capture} />;
-  }
-  return (
-    <NormalCaptureEntry
-      capture={capture}
-      hasSession={hasSession}
-      onUpdateCapture={onUpdateCapture}
-    />
-  );
+  timeoutId: number | null;
 }
 
 export function CaptureList({
@@ -193,6 +14,8 @@ export function CaptureList({
   hasSession,
   onUpdateCapture,
   updateError,
+  onDeleteCapture,
+  onPendingDeletionChange,
   onEnrich,
   enrichPending,
 }: {
@@ -200,13 +23,77 @@ export function CaptureList({
   hasSession: boolean;
   onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
   updateError: string | null;
+  onDeleteCapture?: (captureId: number) => Promise<void>;
+  onPendingDeletionChange?: (captureId: number | null) => void;
   onEnrich?: () => void;
   enrichPending?: boolean;
 }) {
-  const pendingCount = captures.filter((c) => c.entry === null).length;
+  const [pendingDeletion, setPendingDeletion] =
+    useState<PendingDeletion | null>(null);
+  const [deletionAnnouncement, setDeletionAnnouncement] = useState("");
+  const pendingDeletionRef = useRef<PendingDeletion | null>(null);
+  const onDeleteCaptureRef = useRef(onDeleteCapture);
+  onDeleteCaptureRef.current = onDeleteCapture;
+
+  // ponytail: client timer commits on React unmount; use a server-scheduled
+  // deletion if hard-reload durability becomes necessary.
+  useEffect(
+    () => () => {
+      const deletion = pendingDeletionRef.current;
+      if (!deletion || deletion.timeoutId === null) return;
+
+      window.clearTimeout(deletion.timeoutId);
+      const deleteCapture = onDeleteCaptureRef.current;
+      if (deleteCapture) {
+        void deleteCapture(deletion.capture.id).catch(() => {});
+      }
+    },
+    [],
+  );
+  const visibleCaptures = pendingDeletion
+    ? captures.filter((capture) => capture.id !== pendingDeletion.capture.id)
+    : captures;
+  const pendingCount = visibleCaptures.filter((c) => c.entry === null).length;
   const showEnrichButton = !hasSession && pendingCount > 0 && onEnrich != null;
 
-  if (captures.length === 0) {
+  function updatePendingDeletion(deletion: PendingDeletion | null) {
+    pendingDeletionRef.current = deletion;
+    setPendingDeletion(deletion);
+    onPendingDeletionChange?.(deletion?.capture.id ?? null);
+  }
+
+  function requestDelete(capture: Capture) {
+    if (!onDeleteCapture) return;
+
+    const timeoutId = window.setTimeout(async () => {
+      updatePendingDeletion({ capture, timeoutId: null });
+      setDeletionAnnouncement(`Deleting ${capture.item}.`);
+      try {
+        await onDeleteCapture(capture.id);
+        setDeletionAnnouncement(`${capture.item} deleted.`);
+      } catch {
+        // The mutation exposes its message through updateError; restore the row.
+        setDeletionAnnouncement(
+          `${capture.item} could not be deleted and was restored.`,
+        );
+      } finally {
+        updatePendingDeletion(null);
+      }
+    }, DELETE_UNDO_MS);
+    updatePendingDeletion({ capture, timeoutId });
+    setDeletionAnnouncement(
+      `${capture.item} removed. Undo available for five seconds.`,
+    );
+  }
+
+  function undoDelete() {
+    if (!pendingDeletion || pendingDeletion.timeoutId === null) return;
+    window.clearTimeout(pendingDeletion.timeoutId);
+    setDeletionAnnouncement(`${pendingDeletion.capture.item} restored.`);
+    updatePendingDeletion(null);
+  }
+
+  if (visibleCaptures.length === 0 && !pendingDeletion) {
     return (
       <div className="flex flex-1 flex-col overflow-y-auto pb-40">
         <div className="flex flex-1 items-center justify-center">
@@ -222,6 +109,9 @@ export function CaptureList({
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto pb-40">
+      <p className="sr-only" role="status">
+        {deletionAnnouncement}
+      </p>
       {/* Enrich all (N) batch button — mirrors Review screen's "Approve all (N)". */}
       {/* Shown only when no session is active and there are pending one-offs. */}
       {/* Inline by design (1 use). Extract at 3+ uses. See ADR 0006. */}
@@ -230,7 +120,7 @@ export function CaptureList({
           <button
             type="button"
             onClick={() => onEnrich?.()}
-            disabled={enrichPending}
+            disabled={enrichPending || pendingDeletion !== null}
             className="rounded-button border border-accent px-2.5 py-1 text-xs font-medium text-accent cursor-pointer hover:bg-accent hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {enrichPending ? "\u2026" : `Enrich all (${pendingCount})`}
@@ -238,17 +128,44 @@ export function CaptureList({
         </div>
       )}
       {updateError && (
-        <div className="mx-5 mt-2 rounded-button border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+        <div
+          className="mx-5 mt-2 rounded-button border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600"
+          role="alert"
+        >
           {updateError}
         </div>
       )}
       <ul className="px-5">
-        {captures.map((capture) => (
+        {pendingDeletion && (
+          <li className="flex min-h-12 items-center justify-between border-b border-divider text-sm text-dim">
+            <span>
+              {pendingDeletion.timeoutId !== null
+                ? "Capture removed"
+                : "Deleting capture…"}
+            </span>
+            {pendingDeletion.timeoutId !== null && (
+              <button
+                type="button"
+                aria-label={`Undo delete ${pendingDeletion.capture.item}`}
+                onClick={undoDelete}
+                // biome-ignore lint/a11y/noAutofocus: focus follows the confirmed destructive action
+                autoFocus
+                className="min-h-10 rounded-button px-3 font-medium text-accent transition-[background-color,scale] duration-150 ease-out hover:bg-accent-subtle active:scale-[0.96]"
+              >
+                Undo
+              </button>
+            )}
+          </li>
+        )}
+        {visibleCaptures.map((capture) => (
           <CaptureEntry
             key={capture.id}
             capture={capture}
             hasSession={hasSession}
             onUpdateCapture={onUpdateCapture}
+            onRequestDelete={
+              onDeleteCapture && !pendingDeletion ? requestDelete : undefined
+            }
           />
         ))}
       </ul>

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { trpc } from "../../trpc";
 import { CaptureInput } from "./CaptureInput";
-import { CaptureList } from "./CaptureList";
+import { CaptureList } from "./components/CaptureList";
 import { EnrichmentContextEditor } from "./EnrichmentContextEditor";
 import { SessionForm } from "./SessionForm";
 import { SystemPromptEditor } from "./SystemPromptEditor";

--- a/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
+++ b/packages/web/src/screens/CaptureScreen/CaptureScreen.tsx
@@ -10,6 +10,9 @@ export function CaptureScreen() {
   const [showSessionForm, setShowSessionForm] = useState(false);
   const [showPromptEditor, setShowPromptEditor] = useState(false);
   const [showContextEditor, setShowContextEditor] = useState(false);
+  const [pendingDeletionId, setPendingDeletionId] = useState<number | null>(
+    null,
+  );
 
   const utils = trpc.useUtils();
 
@@ -29,6 +32,14 @@ export function CaptureScreen() {
     enabled: showPromptEditor,
   });
 
+  function invalidateCaptures() {
+    return activeSession.data
+      ? utils.capture.listSession.invalidate({
+          sessionId: activeSession.data.id,
+        })
+      : utils.capture.list.invalidate();
+  }
+
   // Mutations
   const setBaseSystemPrompt = trpc.app.setBaseSystemPrompt.useMutation({
     onSuccess: () => {
@@ -43,27 +54,15 @@ export function CaptureScreen() {
   });
 
   const createCapture = trpc.capture.create.useMutation({
-    onSuccess: () => {
-      if (activeSession.data) {
-        utils.capture.listSession.invalidate({
-          sessionId: activeSession.data.id,
-        });
-      } else {
-        utils.capture.list.invalidate();
-      }
-    },
+    onSuccess: invalidateCaptures,
   });
 
   const updateCapture = trpc.capture.update.useMutation({
-    onSuccess: () => {
-      if (activeSession.data) {
-        utils.capture.listSession.invalidate({
-          sessionId: activeSession.data.id,
-        });
-      } else {
-        utils.capture.list.invalidate();
-      }
-    },
+    onSuccess: invalidateCaptures,
+  });
+
+  const deleteCapture = trpc.capture.delete.useMutation({
+    onSuccess: invalidateCaptures,
   });
 
   const openSession = trpc.session.open.useMutation({
@@ -101,6 +100,11 @@ export function CaptureScreen() {
   const activeCaptures = hasSession
     ? (sessionCaptures.data ?? [])
     : (captures.data ?? []);
+  const visibleCaptureCount = activeCaptures.some(
+    (capture) => capture.id === pendingDeletionId,
+  )
+    ? activeCaptures.length - 1
+    : activeCaptures.length;
 
   return (
     <main className="flex flex-1 flex-col relative">
@@ -108,9 +112,9 @@ export function CaptureScreen() {
       <header className="flex items-center justify-between px-5 pt-4 pb-2">
         <h1 className="font-display text-lg font-bold text-ink">Capture</h1>
         <div className="flex items-center gap-2">
-          {activeCaptures.length > 0 && (
-            <span className="rounded-full bg-accent-subtle px-2 text-xs text-dim">
-              {activeCaptures.length}
+          {visibleCaptureCount > 0 && (
+            <span className="rounded-full bg-accent-subtle px-2 text-xs text-dim tabular-nums">
+              {visibleCaptureCount}
             </span>
           )}
           <button
@@ -150,7 +154,7 @@ export function CaptureScreen() {
               <button
                 type="button"
                 onClick={() => closeSession.mutate()}
-                disabled={closeSession.isPending}
+                disabled={closeSession.isPending || pendingDeletionId !== null}
                 className="rounded-button border border-divider px-3 py-1 text-xs font-medium text-dim transition-colors hover:border-red-200 hover:text-red-600 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
               >
                 {closeSession.isPending ? "\u2026" : "Close"}
@@ -180,14 +184,15 @@ export function CaptureScreen() {
             <button
               type="button"
               onClick={() => setShowSessionForm(true)}
-              className="w-full rounded-button border border-dashed border-divider px-3 py-2.5 text-center text-sm text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer"
+              disabled={pendingDeletionId !== null}
+              className="w-full rounded-button border border-dashed border-divider px-3 py-2.5 text-center text-sm text-dim transition-colors hover:border-accent hover:text-accent cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             >
               Start a Session
             </button>
           ) : (
             <SessionForm
               sources={allSources.data ?? []}
-              isPending={openSession.isPending}
+              isPending={openSession.isPending || pendingDeletionId !== null}
               onStart={(name, type, enrichmentContext) =>
                 openSession.mutate({
                   name,
@@ -208,7 +213,13 @@ export function CaptureScreen() {
         onUpdateCapture={(captureId, data) =>
           updateCapture.mutate({ captureId, ...data })
         }
-        updateError={updateCapture.error?.message ?? null}
+        updateError={
+          updateCapture.error?.message ?? deleteCapture.error?.message ?? null
+        }
+        onDeleteCapture={(captureId) =>
+          deleteCapture.mutateAsync({ captureId })
+        }
+        onPendingDeletionChange={setPendingDeletionId}
         onEnrich={() => enrichOneOffs.mutate()}
         enrichPending={enrichOneOffs.isPending}
       />

--- a/packages/web/src/screens/CaptureScreen/captureTypes.ts
+++ b/packages/web/src/screens/CaptureScreen/captureTypes.ts
@@ -1,0 +1,13 @@
+export interface Capture {
+  id: number;
+  item: string;
+  locator: string | null;
+  sourceHint: string | null;
+  entry: { status: string } | null;
+}
+
+export interface CaptureUpdateData {
+  item?: string;
+  locator?: string | null;
+  sourceHint?: string | null;
+}

--- a/packages/web/src/screens/CaptureScreen/components/CaptureEntry.tsx
+++ b/packages/web/src/screens/CaptureScreen/components/CaptureEntry.tsx
@@ -59,53 +59,19 @@ function PendingCaptureEntry({
   }, [confirmingDelete]);
 
   return (
-    <li className="border-b border-divider py-2.5 last:border-b-0">
-      <div className="flex items-center gap-2">
-        <div className="min-w-0 flex-1">
-          <InlineTextEditor
-            value={capture.item}
-            inputLabel={`Item for ${capture.item}`}
-            onSave={(item) => {
-              if (item) onUpdateCapture(capture.id, { item });
-            }}
-          />
-        </div>
-        {onRequestDelete &&
-          (confirmingDelete ? (
-            <div className="flex shrink-0 items-center gap-1">
-              <button
-                type="button"
-                aria-label={`Confirm delete ${capture.item}`}
-                onClick={() => onRequestDelete(capture)}
-                // biome-ignore lint/a11y/noAutofocus: focus follows the Delete disclosure
-                autoFocus
-                className="flex size-10 items-center justify-center rounded-full text-red-600 transition-[background-color,scale] duration-150 ease-out hover:bg-red-50 active:scale-[0.96]"
-              >
-                <CheckIcon className="size-4" aria-hidden="true" />
-              </button>
-              <button
-                type="button"
-                aria-label={`Cancel delete ${capture.item}`}
-                onClick={() => {
-                  restoreDeleteFocus.current = true;
-                  setConfirmingDelete(false);
-                }}
-                className="flex size-10 items-center justify-center rounded-full text-dim transition-[background-color,scale] duration-150 ease-out hover:bg-chip active:scale-[0.96]"
-              >
-                <XMarkIcon className="size-4" aria-hidden="true" />
-              </button>
-            </div>
-          ) : (
-            <button
-              ref={deleteButtonRef}
-              type="button"
-              aria-label={`Delete ${capture.item}`}
-              onClick={() => setConfirmingDelete(true)}
-              className="flex size-10 shrink-0 items-center justify-center rounded-full text-dim transition-[background-color,color,scale] duration-150 ease-out hover:bg-red-50 hover:text-red-600 active:scale-[0.96]"
-            >
-              <TrashIcon className="size-4" aria-hidden="true" />
-            </button>
-          ))}
+    <li
+      className={`relative border-b border-divider py-2.5 last:border-b-0 ${
+        onRequestDelete ? (confirmingDelete ? "pr-24" : "pr-12") : ""
+      }`}
+    >
+      <div className="min-w-0">
+        <InlineTextEditor
+          value={capture.item}
+          inputLabel={`Item for ${capture.item}`}
+          onSave={(item) => {
+            if (item) onUpdateCapture(capture.id, { item });
+          }}
+        />
       </div>
       <div className="mt-0.5 flex items-center gap-1.5 text-xs">
         {hasSession ? (
@@ -128,6 +94,45 @@ function PendingCaptureEntry({
           />
         )}
       </div>
+      {onRequestDelete && (
+        <div className="absolute right-0 top-2.5 flex shrink-0 items-center gap-1">
+          {confirmingDelete ? (
+            <>
+              <button
+                type="button"
+                aria-label={`Confirm delete ${capture.item}`}
+                onClick={() => onRequestDelete(capture)}
+                // biome-ignore lint/a11y/noAutofocus: focus follows the Delete disclosure
+                autoFocus
+                className="flex size-10 items-center justify-center rounded-full text-red-600 transition-[background-color,scale] duration-150 ease-out hover:bg-red-50 active:scale-[0.96]"
+              >
+                <CheckIcon className="size-4" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Cancel delete ${capture.item}`}
+                onClick={() => {
+                  restoreDeleteFocus.current = true;
+                  setConfirmingDelete(false);
+                }}
+                className="flex size-10 items-center justify-center rounded-full text-dim transition-[background-color,scale] duration-150 ease-out hover:bg-chip active:scale-[0.96]"
+              >
+                <XMarkIcon className="size-4" aria-hidden="true" />
+              </button>
+            </>
+          ) : (
+            <button
+              ref={deleteButtonRef}
+              type="button"
+              aria-label={`Delete ${capture.item}`}
+              onClick={() => setConfirmingDelete(true)}
+              className="flex size-10 shrink-0 items-center justify-center rounded-full text-dim transition-[background-color,color,scale] duration-150 ease-out hover:bg-red-50 hover:text-red-600 active:scale-[0.96]"
+            >
+              <TrashIcon className="size-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      )}
     </li>
   );
 }

--- a/packages/web/src/screens/CaptureScreen/components/CaptureEntry.tsx
+++ b/packages/web/src/screens/CaptureScreen/components/CaptureEntry.tsx
@@ -1,0 +1,157 @@
+import { CheckIcon, TrashIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useEffect, useRef, useState } from "react";
+import type { Capture, CaptureUpdateData } from "../captureTypes";
+import { InlineTextEditor } from "./InlineTextEditor";
+
+function LockedCaptureEntry({ capture }: { capture: Capture }) {
+  const isProcessing = capture.entry?.status === "processing";
+
+  return (
+    <li className="border-b border-divider py-2.5 last:border-b-0">
+      <div className="flex items-center gap-2.5 font-display text-base font-semibold text-ink/80">
+        {isProcessing && (
+          <span className="relative flex h-2 w-2 shrink-0">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-dim opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-dim" />
+          </span>
+        )}
+        {capture.item}
+      </div>
+      <div className="mt-0.5 flex items-center gap-1.5 text-xs text-dim/60">
+        {capture.locator && (
+          <span className="font-medium text-accent/60">{capture.locator}</span>
+        )}
+        {capture.sourceHint && (
+          <>
+            {capture.locator && (
+              <span className="select-none text-divider">&middot;</span>
+            )}
+            <span className="rounded-[5px] bg-chip/50 px-1.5 py-px font-medium text-chip-text/60">
+              {capture.sourceHint}
+            </span>
+          </>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function PendingCaptureEntry({
+  capture,
+  hasSession,
+  onUpdateCapture,
+  onRequestDelete,
+}: {
+  capture: Capture;
+  hasSession: boolean;
+  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
+  onRequestDelete?: (capture: Capture) => void;
+}) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreDeleteFocus = useRef(false);
+
+  useEffect(() => {
+    if (!confirmingDelete && restoreDeleteFocus.current) {
+      deleteButtonRef.current?.focus();
+      restoreDeleteFocus.current = false;
+    }
+  }, [confirmingDelete]);
+
+  return (
+    <li className="border-b border-divider py-2.5 last:border-b-0">
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <InlineTextEditor
+            value={capture.item}
+            inputLabel={`Item for ${capture.item}`}
+            onSave={(item) => {
+              if (item) onUpdateCapture(capture.id, { item });
+            }}
+          />
+        </div>
+        {onRequestDelete &&
+          (confirmingDelete ? (
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                aria-label={`Confirm delete ${capture.item}`}
+                onClick={() => onRequestDelete(capture)}
+                // biome-ignore lint/a11y/noAutofocus: focus follows the Delete disclosure
+                autoFocus
+                className="flex size-10 items-center justify-center rounded-full text-red-600 transition-[background-color,scale] duration-150 ease-out hover:bg-red-50 active:scale-[0.96]"
+              >
+                <CheckIcon className="size-4" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Cancel delete ${capture.item}`}
+                onClick={() => {
+                  restoreDeleteFocus.current = true;
+                  setConfirmingDelete(false);
+                }}
+                className="flex size-10 items-center justify-center rounded-full text-dim transition-[background-color,scale] duration-150 ease-out hover:bg-chip active:scale-[0.96]"
+              >
+                <XMarkIcon className="size-4" aria-hidden="true" />
+              </button>
+            </div>
+          ) : (
+            <button
+              ref={deleteButtonRef}
+              type="button"
+              aria-label={`Delete ${capture.item}`}
+              onClick={() => setConfirmingDelete(true)}
+              className="flex size-10 shrink-0 items-center justify-center rounded-full text-dim transition-[background-color,color,scale] duration-150 ease-out hover:bg-red-50 hover:text-red-600 active:scale-[0.96]"
+            >
+              <TrashIcon className="size-4" aria-hidden="true" />
+            </button>
+          ))}
+      </div>
+      <div className="mt-0.5 flex items-center gap-1.5 text-xs">
+        {hasSession ? (
+          <InlineTextEditor
+            value={capture.locator}
+            inputLabel={`Locator for ${capture.item}`}
+            emptyLabel="+ add locator"
+            allowEmpty
+            variant="metadata"
+            onSave={(locator) => onUpdateCapture(capture.id, { locator })}
+          />
+        ) : (
+          <InlineTextEditor
+            value={capture.sourceHint}
+            inputLabel={`Source Hint for ${capture.item}`}
+            emptyLabel="+ add source"
+            allowEmpty
+            variant="metadata"
+            onSave={(sourceHint) => onUpdateCapture(capture.id, { sourceHint })}
+          />
+        )}
+      </div>
+    </li>
+  );
+}
+
+export function CaptureEntry({
+  capture,
+  hasSession,
+  onUpdateCapture,
+  onRequestDelete,
+}: {
+  capture: Capture;
+  hasSession: boolean;
+  onUpdateCapture: (captureId: number, data: CaptureUpdateData) => void;
+  onRequestDelete?: (capture: Capture) => void;
+}) {
+  if (capture.entry) {
+    return <LockedCaptureEntry capture={capture} />;
+  }
+  return (
+    <PendingCaptureEntry
+      capture={capture}
+      hasSession={hasSession}
+      onUpdateCapture={onUpdateCapture}
+      onRequestDelete={onRequestDelete}
+    />
+  );
+}

--- a/packages/web/src/screens/CaptureScreen/components/CaptureList.tsx
+++ b/packages/web/src/screens/CaptureScreen/components/CaptureList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import type { Capture, CaptureUpdateData } from "./captureTypes";
-import { CaptureEntry } from "./components/CaptureEntry";
+import type { Capture, CaptureUpdateData } from "../captureTypes";
+import { CaptureEntry } from "./CaptureEntry";
 
 const DELETE_UNDO_MS = 5_000;
 

--- a/packages/web/src/screens/CaptureScreen/components/InlineTextEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/components/InlineTextEditor.tsx
@@ -54,8 +54,8 @@ export function InlineTextEditor({
         onBlur={save}
         className={
           variant === "item"
-            ? "min-h-10 w-full rounded-[5px] border border-accent bg-surface px-2 font-display text-base font-semibold text-ink outline-none focus:ring-1 focus:ring-accent"
-            : "min-h-10 min-w-32 rounded-[5px] border border-accent bg-surface px-2 font-medium text-xs text-ink outline-none focus:ring-1 focus:ring-accent"
+            ? "h-6 w-full rounded-[5px] border border-accent bg-surface px-2 font-display text-base font-semibold text-ink outline-none focus:ring-1 focus:ring-accent"
+            : "h-5 min-w-32 rounded-[5px] border border-accent bg-surface px-2 font-medium text-xs text-ink outline-none focus:ring-1 focus:ring-accent"
         }
       />
     );
@@ -71,8 +71,8 @@ export function InlineTextEditor({
       }}
       className={
         variant === "item"
-          ? "min-h-10 w-full text-left font-display text-base font-semibold text-ink transition-[color,scale] duration-150 ease-out hover:text-accent active:scale-[0.96]"
-          : "min-h-10 text-left font-medium text-xs text-accent transition-[color,scale] duration-150 ease-out hover:text-ink active:scale-[0.96]"
+          ? "min-h-6 w-full text-left font-display text-base font-semibold text-ink transition-[color,scale] duration-150 ease-out hover:text-accent active:scale-[0.96]"
+          : "min-h-6 text-left font-medium text-xs text-accent transition-[color,scale] duration-150 ease-out hover:text-ink active:scale-[0.96]"
       }
     >
       <span

--- a/packages/web/src/screens/CaptureScreen/components/InlineTextEditor.tsx
+++ b/packages/web/src/screens/CaptureScreen/components/InlineTextEditor.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+
+export function InlineTextEditor({
+  value,
+  inputLabel,
+  emptyLabel,
+  allowEmpty = false,
+  variant = "item",
+  onSave,
+}: {
+  value: string | null;
+  inputLabel: string;
+  emptyLabel?: string;
+  allowEmpty?: boolean;
+  variant?: "item" | "metadata";
+  onSave: (value: string | null) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+
+  function save() {
+    const trimmed = draft.trim();
+    const nextValue = trimmed || null;
+    if (!nextValue && !allowEmpty) {
+      setDraft(value ?? "");
+      setEditing(false);
+      return;
+    }
+    if (nextValue !== value) {
+      onSave(nextValue);
+    }
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <input
+        // biome-ignore lint/a11y/noAutofocus: intentional for inline edit UX
+        autoFocus
+        aria-label={inputLabel}
+        type="text"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            save();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            setDraft(value ?? "");
+            setEditing(false);
+          }
+        }}
+        onBlur={save}
+        className={
+          variant === "item"
+            ? "min-h-10 w-full rounded-[5px] border border-accent bg-surface px-2 font-display text-base font-semibold text-ink outline-none focus:ring-1 focus:ring-accent"
+            : "min-h-10 min-w-32 rounded-[5px] border border-accent bg-surface px-2 font-medium text-xs text-ink outline-none focus:ring-1 focus:ring-accent"
+        }
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Edit ${inputLabel}`}
+      onClick={() => {
+        setDraft(value ?? "");
+        setEditing(true);
+      }}
+      className={
+        variant === "item"
+          ? "min-h-10 w-full text-left font-display text-base font-semibold text-ink transition-[color,scale] duration-150 ease-out hover:text-accent active:scale-[0.96]"
+          : "min-h-10 text-left font-medium text-xs text-accent transition-[color,scale] duration-150 ease-out hover:text-ink active:scale-[0.96]"
+      }
+    >
+      <span
+        className={
+          value
+            ? undefined
+            : "rounded-[5px] border border-dashed border-divider px-1.5 py-px text-dim"
+        }
+      >
+        {value || emptyLabel}
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- edit Pending Capture Items and context-appropriate Locator/Source Hint values inline
- atomically reject edits and deletion once Enrichment work exists
- delete with inline confirmation and a five-second Undo window
- keep counts, lifecycle controls, focus, and accessibility feedback consistent during deletion

## Verification

- `pnpm --filter server test` — 132 passed
- `pnpm --filter web test` — 82 passed
- `pnpm typecheck`
- server and web production builds
- `pnpm lint` — passes with three pre-existing warnings in `word-bank.test.ts`
- Chromium at 390×844 and 1440×900: Item/metadata edits, clear, Enter/blur/Escape, confirmation/cancel, Undo/expiry, disabled Close/Enrich, locked processing UI, and HTTP 409 rejection after Enrichment begins

Closes #55
